### PR TITLE
Improve simulator compatibility

### DIFF
--- a/misoclib/mem/litesata/core/command/__init__.py
+++ b/misoclib/mem/litesata/core/command/__init__.py
@@ -61,7 +61,7 @@ class LiteSATACommandTX(Module):
             transport.sink.sop.eq(1),
             transport.sink.eop.eq(1),
             transport.sink.c.eq(1),
-            If(transport.sink.stb & transport.sink.ack,
+            If(sink.stb & transport.sink.ack,
                 If(is_write,
                     NextState("WAIT_DMA_ACTIVATE")
                 ).Else(
@@ -80,7 +80,7 @@ class LiteSATACommandTX(Module):
             )
         )
         fsm.act("SEND_DATA",
-            dwords_counter.ce.eq(sink.stb & sink.ack),
+            dwords_counter.ce.eq(sink.stb & transport.sink.ack),
 
             transport.sink.stb.eq(sink.stb),
             transport.sink.sop.eq(dwords_counter.value == 0),
@@ -88,7 +88,7 @@ class LiteSATACommandTX(Module):
                                   sink.eop),
 
             sink.ack.eq(transport.sink.ack),
-            If(sink.stb & sink.ack,
+            If(sink.stb & transport.sink.ack,
                 If(sink.eop,
                     NextState("IDLE")
                 ).Elif(dwords_counter.value == (fis_max_dwords-1),

--- a/misoclib/mem/litesata/core/transport/__init__.py
+++ b/misoclib/mem/litesata/core/transport/__init__.py
@@ -74,7 +74,7 @@ class LiteSATATransportTX(Module):
         fsm.act("SEND_DATA",
             data_send.eq(1),
             sink.ack.eq(link.sink.ack),
-            If(sink.stb & sink.eop & sink.ack,
+            If(sink.stb & sink.eop & link.sink.ack,
                 NextState("IDLE")
             )
         )


### PR DESCRIPTION
Some simulators, notably Vivado's XSIM endlessly relaunches
combinatorial processes that read and write the same register.

This patch avoids that problem by only reading from registers that
are not written to in the same process. The replaced registers are
equivalent, so no logical changes are introduced