### PR TITLE
Specify Python version 3.5 specifically

### DIFF
--- a/README
+++ b/README
@@ -38,7 +38,7 @@ modules.
 0. If cloned from Git without the --recursive option, get the submodules:
    git submodule update --init
 
-1. Install Python 3.3+, Migen and FPGA vendor's development tools.
+1. Install Python 3.5, Migen and FPGA vendor's development tools.
    Get Migen from: https://github.com/m-labs/migen
    For flterm, you will also need asyncserial and pyserial:
    https://github.com/m-labs/asyncserial


### PR DESCRIPTION
3.3 as recommended before won't actually work because of asyncserial, and the current most recent (3.6) won't work yet due to issue 62. Recommending 3.5 specifically might save people some time.