### PR TITLE
Use wrap_ts function to wrap signals of core that need tristate output.

### DIFF
--- a/misoc/cores/gpio.py
+++ b/misoc/cores/gpio.py
@@ -24,8 +24,7 @@ class GPIOTristate(Module, AutoCSR):
         self._oe = CSRStorage(l, reset=reset_oe)
 
         for n, signal in enumerate(signals):
-            ts = TSTriple(1)
-            self.specials += ts.get_tristate(signal)
+            ts = wrap_ts(signal, self)
 
             status = Signal()
             self.comb += self._in.status[n].eq(status)

--- a/misoc/cores/i2c.py
+++ b/misoc/cores/i2c.py
@@ -209,15 +209,13 @@ class I2CMaster(Module):
         ]
 
         # I/O
-        self.scl_t = TSTriple()
-        self.specials += self.scl_t.get_tristate(pads.scl)
+        self.scl_t = wrap_ts(pads.scl, self)
         self.comb += [
             self.scl_t.oe.eq(~i2c.scl_o),
             self.scl_t.o.eq(0),
         ]
 
-        self.sda_t = TSTriple()
-        self.specials += self.sda_t.get_tristate(pads.sda)
+        self.sda_t = wrap_ts(pads.sda, self)
         self.comb += [
             self.sda_t.oe.eq(~i2c.sda_o),
             self.sda_t.o.eq(0),

--- a/misoc/cores/nor_flash_16.py
+++ b/misoc/cores/nor_flash_16.py
@@ -10,10 +10,11 @@ class NorFlash16(Module):
 
         ###
 
-        data = TSTriple(16)
+        data = wrap_ts(pads.d, self)
+        if len(data.o) != 16:
+            raise ValueError("pads.d input not of width 16")
         lsb = Signal()
 
-        self.specials += data.get_tristate(pads.d)
         self.comb += [
             data.oe.eq(pads.oe_n),
             pads.ce_n.eq(0)

--- a/misoc/cores/spi.py
+++ b/misoc/cores/spi.py
@@ -333,8 +333,7 @@ class SPIMaster(Module, AutoCSR):
                 ~self._cs_polarity.storage)
         offset = 0
         for pads in pads_list:
-            cs_n_t = TSTriple(len(pads.cs_n))
-            self.specials += cs_n_t.get_tristate(pads.cs_n)
+            cs_n_t = wrap_ts(pads.cs_n, self)
             self.comb += [
                 cs_n_t.oe.eq(~self._offline.storage),
                 cs_n_t.o.eq(all_cs[offset:]),
@@ -345,8 +344,7 @@ class SPIMaster(Module, AutoCSR):
         miso_r = Signal(len(cs))
         mosi_t_i_r = Signal(len(cs))
         for pads in pads_list:
-            clk_t = TSTriple()
-            self.specials += clk_t.get_tristate(pads.clk)
+            clk_t = wrap_ts(pads.clk, self)
             self.comb += [
                 clk_t.oe.eq(~self._offline.storage),
             ]
@@ -357,8 +355,7 @@ class SPIMaster(Module, AutoCSR):
                 )
             ]
 
-            mosi_t = TSTriple()
-            self.specials += mosi_t.get_tristate(pads.mosi)
+            mosi_t = wrap_ts(pads.mosi, self)
             self.comb += [
                 mosi_t.oe.eq(~self._offline.storage & spi.cs &
                             (spi.oe | ~self._half_duplex.storage)),

--- a/misoc/cores/spi2.py
+++ b/misoc/cores/spi2.py
@@ -236,22 +236,14 @@ class SPIInterface(Module):
 
         i = 0
         for p in pads:
-            n = len(p.cs_n)
-            cs = TSTriple(n)
+            cs = wrap_ts(p.cs_n, self)
+            n = len(cs.o)
             cs.o.reset = C((1 << n) - 1)
-            clk = TSTriple()
-            mosi = TSTriple()
-            miso = TSTriple()
+            clk = wrap_ts(p.clk, self)
+            mosi = wrap_ts(p.mosi, self) if hasattr(p, "mosi") else TSTriple()
+            miso = wrap_ts(p.miso, self) if hasattr(p, "miso") else TSTriple()
             miso_reg = Signal(reset_less=True)
             mosi_reg = Signal(reset_less=True)
-            self.specials += [
-                    cs.get_tristate(p.cs_n),
-                    clk.get_tristate(p.clk),
-            ]
-            if hasattr(p, "mosi"):
-                self.specials += mosi.get_tristate(p.mosi)
-            if hasattr(p, "miso"):
-                self.specials += miso.get_tristate(p.miso)
             self.comb += [
                     miso.oe.eq(0),
                     mosi.o.eq(self.sdo),


### PR DESCRIPTION
This PR uses the wrap_ts function of https://github.com/m-labs/migen/pull/147. This PR should be taken if https://github.com/m-labs/migen/pull/148 is taken.

