### PR TITLE
spi2: add iCE40 differential interface

### DIFF
--- a/misoc/cores/spi2.py
+++ b/misoc/cores/spi2.py
@@ -337,9 +337,9 @@ class SPIInterfaceiCE40Diff(Module):
 
     3-wire SPI (half-duplex) is not supported.
 
-    When using a `miso` signal, make sure to not request the `p` side
-    of the differential pair to not confuse yosys/nextpnr (pass `None`
-    or nothing for `pads.miso`).
+    When using a `miso` signal, make sure to not request the complementary side
+    of the differential pair to not confuse yosys/nextpnr (pass `None` or
+    nothing for `pads_n.miso`).
     """
     def __init__(self, pads, pads_n):
         self.cs = Signal(len(getattr(pads, "cs_n", [0])))
@@ -421,13 +421,14 @@ class SPIInterfaceiCE40Diff(Module):
                                       i_D_OUT_0=~self.sdo)
 
         # MISO
-        if hasattr(pads_n, "miso"):
-            # make sure pads.miso is not requested to not confuse yosys/nextpnr
-            assert getattr(pads, "miso", None) is None
+        if hasattr(pads, "miso"):
+            # make sure pads_n.miso is not requested
+            # to not confuse yosys/nextpnr
+            assert getattr(pads_n, "miso", None) is None
             self.specials += Instance("SB_IO",
                                       p_PIN_TYPE=C(0b000001, 6),
                                       p_IO_STANDARD="SB_LVDS_INPUT",
-                                      io_PACKAGE_PIN=pads_n.miso,
+                                      io_PACKAGE_PIN=pads.miso,
                                       i_D_OUT_0=self.sdo,
                                       o_D_IN_0=miso)
 

--- a/misoc/cores/spi2.py
+++ b/misoc/cores/spi2.py
@@ -370,7 +370,7 @@ class SPIInterfaceiCE40Diff(Module):
                                 & self.cs) ^ ~self.cs_polarity),
                         clk.eq(self.clk_next ^ self.clk_polarity)),
                       If(self.sample,
-                         miso_reg.eq(~miso),
+                         miso_reg.eq(miso),
                          mosi_reg.eq(mosi)),
         ]
 

--- a/misoc/cores/spi2.py
+++ b/misoc/cores/spi2.py
@@ -370,7 +370,7 @@ class SPIInterfaceiCE40Diff(Module):
                                 & self.cs) ^ ~self.cs_polarity),
                         clk.eq(self.clk_next ^ self.clk_polarity)),
                       If(self.sample,
-                         miso_reg.eq(miso),
+                         miso_reg.eq(~miso),
                          mosi_reg.eq(mosi)),
         ]
 


### PR DESCRIPTION
This patch adds support for SPI-over-LVDS for iCE40 platforms.

The logic is taken straight from the 7-Series differential interface, which produces a lot of code duplication. Refactoring would be great. Would for example differential tristate buffers as generic `Specials` be a good idea?

The `miso` buffer suffers the same problems as `DifferentialInput` discussed in m-labs/migen#178 with yosys/nextpnr getting confused if the `p` side of the differential pair is in the pcf.

Reviews most welcome. Thanks in advance!