### PR TITLE
cores: replace use of add_sources(), remove use of add_verilog_include_path()

### DIFF
--- a/misoc/cores/lm32/core.py
+++ b/misoc/cores/lm32/core.py
@@ -57,10 +57,4 @@ class LM32(Module):
         # add Verilog sources
         vdir = os.path.join(
             os.path.abspath(os.path.dirname(__file__)), "verilog")
-        platform.add_sources(os.path.join(vdir, "submodule", "rtl"),
-                "lm32_cpu.v", "lm32_instruction_unit.v", "lm32_decoder.v",
-                "lm32_load_store_unit.v", "lm32_adder.v", "lm32_addsub.v", "lm32_logic_op.v",
-                "lm32_shifter.v", "lm32_multiplier.v", "lm32_mc_arithmetic.v",
-                "lm32_interrupt.v", "lm32_ram.v", "lm32_dp_ram.v", "lm32_icache.v",
-                "lm32_dcache.v", "lm32_debug.v", "lm32_itlb.v", "lm32_dtlb.v")
-        platform.add_verilog_include_path(vdir)
+        platform.add_source_dir(os.path.join(vdir, "submodule", "rtl"))

--- a/misoc/cores/vexriscv/core.py
+++ b/misoc/cores/vexriscv/core.py
@@ -46,5 +46,4 @@ class VexRiscv(Module):
 
         # add Verilog sources
         vdir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "verilog")
-        platform.add_sources(os.path.join(vdir), "VexRiscv.v")
-        platform.add_verilog_include_path(vdir)
+        platform.add_source(os.path.join(vdir, "VexRiscv.v"))


### PR DESCRIPTION
As proposed in [migen #201](https://github.com/m-labs/migen/pull/201) here's what needs to be done to remove `add_sources()` with an explicit list of files, which omitted files that are only referenced through `include` in Verilog.

In consequence, all files that are added through `add_source_dir()` occur in the output's `top.tcl`.

It also removes all verilog_include paths as the `include` directives only refer to files in the same source directory.
