### PR TITLE
liteeth: Add support for 10/100Mbps via SGMII

### DIFF
--- a/misoc/cores/liteeth_mini/phy/a7_1000basex.py
+++ b/misoc/cores/liteeth_mini/phy/a7_1000basex.py
@@ -811,3 +811,13 @@ class A7_1000BASEX(Module):
             gearbox.tx_data.eq(pcs.tbi_tx),
             pcs.tbi_rx.eq(gearbox.rx_data)
         ]
+
+        # Exposed pins for microscope probing
+        self.pll_lock = tx_init.qpll_lock
+        self.tx_reset_done = tx_reset_done
+        self.rx_reset_done = tx_reset_done
+        self.txdata = tx_data
+        self.rxdata = rx_data
+        self.tbi_tx = pcs.tbi_tx
+        self.tbi_rx = pcs.tbi_rx
+        self.link_partner_adv_ability = pcs.link_partner_adv_ability

--- a/misoc/cores/liteeth_mini/phy/pcs_1000basex.py
+++ b/misoc/cores/liteeth_mini/phy/pcs_1000basex.py
@@ -31,6 +31,10 @@ class TransmitPath(Module):
 
         self.submodules.encoder = code_8b10b.Encoder(lsb_first=lsb_first)
 
+        # SGMII Speed Adaptation
+        timer = Signal(max=1000)
+        self.sgmii_speed = Signal(2)
+
         # # #
 
         parity = Signal()
@@ -41,29 +45,52 @@ class TransmitPath(Module):
         load_config_reg_buffer = Signal()
         self.sync += If(load_config_reg_buffer, config_reg_buffer.eq(self.config_reg))
 
+        # Timer for SGMII data rates
+        timer_en = Signal()
+        self.sync += [
+            If(~timer_en | (timer == 0),
+                If(self.sgmii_speed == 0b00,
+                    timer.eq(99)
+                ).Elif(self.sgmii_speed == 0b01,
+                    timer.eq(9)
+                ).Elif(self.sgmii_speed == 0b10,
+                    timer.eq(0)
+                )
+            ).Elif(timer_en,
+                timer.eq(timer - 1)
+            )
+        ]
+
         fsm = FSM()
         self.submodules += fsm
 
         fsm.act("START",
-            self.tx_ack.eq(1),  # discard TX data if we are in config_reg phase
             If(self.config_stb,
+                self.tx_ack.eq(1),  # discard TX data if we are in config_reg phase
                 load_config_reg_buffer.eq(1),
                 self.encoder.k[0].eq(1),
                 self.encoder.d[0].eq(K(28, 5)),
                 NextState("CONFIG_D")
             ).Else(
                 If(self.tx_stb,
-                    # the first byte of the preamble is replaced by /S/
+                    # the first byte sent is replaced by /S/
+                    self.tx_ack.eq((timer == 0)),
+                    timer_en.eq(1),
                     self.encoder.k[0].eq(1),
                     self.encoder.d[0].eq(K(27, 7)),
                     NextState("DATA")
                 ).Else(
+                    self.tx_ack.eq(1),  # discard TX data
                     self.encoder.k[0].eq(1),
                     self.encoder.d[0].eq(K(28, 5)),
                     NextState("IDLE")
                 )
             )
         )
+        # /K28.5/ == /C/
+        # It is the first code-group in an ordered_set that provides 
+        # synchronisation of bits & code-groups as well as establishes 
+        # alignment of ordered_sets.
         fsm.act("CONFIG_D",
             If(c_type,
                 self.encoder.d[0].eq(D(2, 2))
@@ -94,10 +121,12 @@ class TransmitPath(Module):
             NextState("START")
         )
         fsm.act("DATA",
-            self.tx_ack.eq(1),
             If(self.tx_stb,
+                self.tx_ack.eq((timer == 0)),
+                timer_en.eq(1),
                 self.encoder.d[0].eq(self.tx_data)
             ).Else(
+                self.tx_ack.eq(1),
                 # /T/
                 self.encoder.k[0].eq(1),
                 self.encoder.d[0].eq(K(29, 7)),
@@ -133,14 +162,21 @@ class ReceivePath(Module):
 
         self.submodules.decoder = code_8b10b.Decoder(lsb_first=lsb_first)
 
+        # SGMII Speed Adaptation
+        timer = Signal(max=1000)
+        self.sgmii_speed = Signal(2)
+        self.sample_en = Signal()
+
         # # #
 
         config_reg_lsb = Signal(8)
         load_config_reg_lsb = Signal()
-        load_config_reg_msb = Signal()
+        self.load_config_reg_msb = load_config_reg_msb = Signal()
         self.sync += [
             self.seen_config_reg.eq(0),
-            If(load_config_reg_lsb, config_reg_lsb.eq(self.decoder.d)),
+            If(load_config_reg_lsb, 
+                config_reg_lsb.eq(self.decoder.d)
+            ),
             If(load_config_reg_msb,
                 self.config_reg.eq(Cat(config_reg_lsb, self.decoder.d)),
                 self.seen_config_reg.eq(1)
@@ -150,6 +186,26 @@ class ReceivePath(Module):
         first_preamble_byte = Signal()
         self.comb += self.rx_data.eq(Mux(first_preamble_byte, 0x55, self.decoder.d))
 
+        # Timer for SGMII data rates
+        timer_en = Signal()
+        self.sync += [
+            If(~timer_en | (timer == 0),
+                If(self.sgmii_speed == 0b00,
+                    timer.eq(99)
+                ).Elif(self.sgmii_speed == 0b01,
+                    timer.eq(9)
+                ).Elif(self.sgmii_speed == 0b10,
+                    timer.eq(0)
+                )
+            ).Elif(timer_en,
+                timer.eq(timer - 1)
+            )
+        ]
+
+        # Speed adaptation
+        self.comb += self.sample_en.eq(self.rx_en & (timer == 0))
+
+        # PCS receive state diagram, Figure 36-7a/b
         fsm = FSM()
         self.submodules += fsm
 
@@ -160,11 +216,17 @@ class ReceivePath(Module):
                 ),
                 If(self.decoder.d == K(27, 7),
                     self.rx_en.eq(1),
+                    timer_en.eq(1),
                     first_preamble_byte.eq(1),
                     NextState("DATA")
                 )
             )
         )
+        # /K28.5/ == /C/
+        # It is the first code-group in an ordered_set that provides 
+        # synchronisation of bits & code-groups as well as establishes 
+        # alignment of ordered_sets.
+        # RX_CB
         fsm.act("K28_5",
             NextState("START"),
             If(~self.decoder.k,
@@ -179,10 +241,12 @@ class ReceivePath(Module):
                 ),
             )
         )
+        # RX_CC
         fsm.act("CONFIG_REG_LSB",
             If(self.decoder.k,
                 If(self.decoder.d == K(27, 7),
                     self.rx_en.eq(1),
+                    timer_en.eq(1),
                     first_preamble_byte.eq(1),
                     NextState("DATA")
                 ).Else(
@@ -193,6 +257,7 @@ class ReceivePath(Module):
                 NextState("CONFIG_REG_MSB")
             )
         )
+        # RX_CD
         fsm.act("CONFIG_REG_MSB",
             If(~self.decoder.k,
                 load_config_reg_msb.eq(1)
@@ -203,7 +268,8 @@ class ReceivePath(Module):
             If(self.decoder.k,
                 NextState("START")
             ).Else(
-                self.rx_en.eq(1)
+                self.rx_en.eq(1),
+                timer_en.eq(1)
             )
         )
 
@@ -223,6 +289,10 @@ class PCS(Module):
         self.link_up = Signal()
         self.restart = Signal()
 
+        # SGMII Speed Adaptation
+        is_sgmii = Signal()
+        self.link_partner_adv_ability = Signal(16)
+
         # # #
         
         # endpoint interface
@@ -235,7 +305,7 @@ class PCS(Module):
         rx_en_d = Signal()
         self.sync.eth_rx += [
             rx_en_d.eq(self.rx.rx_en),
-            self.source.stb.eq(self.rx.rx_en),
+            self.source.stb.eq(self.rx.sample_en),
             self.source.data.eq(self.rx.rx_data)
         ]
         self.comb += self.source.eop.eq(~self.rx.rx_en & rx_en_d)
@@ -262,27 +332,38 @@ class PCS(Module):
         ]
 
         autoneg_ack = Signal()
-        self.comb += self.tx.config_reg.eq((1 << 5) | (autoneg_ack << 14))
+        self.comb += self.tx.config_reg.eq(
+            (is_sgmii) |       # SGMII-specific
+            (~is_sgmii << 5) | # Full-duplex
+            (autoneg_ack << 14)     # ACK
+        )
 
-        rx_config_reg = PulseSynchronizer("eth_rx", "eth_tx")
+        rx_config_reg_abi = PulseSynchronizer("eth_rx", "eth_tx")
         rx_config_reg_ack = PulseSynchronizer("eth_rx", "eth_tx")
-        self.submodules += rx_config_reg, rx_config_reg_ack
+        self.submodules += [
+            rx_config_reg_abi, rx_config_reg_ack
+        ]
 
         more_ack_timer = ClockDomainsRenamer("eth_tx")(
             WaitTimer(ceil(more_ack_time*125e6)))
         self.submodules += more_ack_timer
 
+        fsm_inited = Signal()
+        config_reg_empty = Signal()
+
         fsm = ClockDomainsRenamer("eth_tx")(FSM())
         self.submodules += fsm
 
-        fsm.act("AUTONEG_WAIT_CONFIG_REG",
-            self.tx.config_stb.eq(1),
-            If(rx_config_reg.o|rx_config_reg_ack.o,
+        # Only use checker for ability advertisement in non-SGMII mode
+        fsm.act("AUTONEG_WAIT_ABI",
+            self.tx.config_stb.eq(fsm_inited),
+            If(rx_config_reg_abi.o,
+                NextValue(fsm_inited, 1),
                 NextState("AUTONEG_WAIT_ACK")
             ),
             If(checker_tick & ~checker_ok,
                 self.restart.eq(1),
-                NextState("AUTONEG_WAIT_CONFIG_REG")
+                NextState("AUTONEG_WAIT_ABI")
             )
         )
         fsm.act("AUTONEG_WAIT_ACK",
@@ -293,9 +374,10 @@ class PCS(Module):
             ),
             If(checker_tick & ~checker_ok,
                 self.restart.eq(1),
-                NextState("AUTONEG_WAIT_CONFIG_REG")
+                NextState("AUTONEG_WAIT_ABI")
             )
         )
+        # COMPLETE_ACKNOWLEDGE
         fsm.act("AUTONEG_SEND_MORE_ACK",
             self.tx.config_stb.eq(1),
             autoneg_ack.eq(1),
@@ -305,37 +387,60 @@ class PCS(Module):
             ),
             If(checker_tick & ~checker_ok,
                 self.restart.eq(1),
-                NextState("AUTONEG_WAIT_CONFIG_REG")
+                NextState("AUTONEG_WAIT_ABI")
             )
         )
+        # LINK_OK
         fsm.act("RUNNING",
             self.link_up.eq(1),
-            If(checker_tick & ~checker_ok,
+            If((checker_tick & ~checker_ok) | config_reg_empty,
                 self.restart.eq(1),
-                NextState("AUTONEG_WAIT_CONFIG_REG")
+                NextState("AUTONEG_WAIT_ABI")
             )
         )
 
         c_counter = Signal(max=5)
         previous_config_reg = Signal(16)
+        preack_config_reg = Signal(16)
         self.sync.eth_rx += [
+            # Restart consistency counter
             If(self.rx.seen_config_reg,
                 c_counter.eq(4)
             ).Elif(c_counter != 0,
                 c_counter.eq(c_counter - 1)
             ),
 
+            rx_config_reg_abi.i.eq(0),
             rx_config_reg_ack.i.eq(0),
-            rx_config_reg.i.eq(0),
             If(self.rx.seen_config_reg,
                 previous_config_reg.eq(self.rx.config_reg),
-                # two identical config_reg in immediate succession
-                If((c_counter == 1) & (previous_config_reg == self.rx.config_reg),
-                    If(previous_config_reg[14],
+                If((c_counter == 1) & 
+                    ((previous_config_reg|0x4000) == (self.rx.config_reg|0x4000)) &
+                    ((self.rx.config_reg | 1) != 1),
+                    # Ability match
+                    rx_config_reg_abi.i.eq(1),
+                    preack_config_reg.eq(previous_config_reg),
+                    # Acknowledgement/Consistency match
+                    If((previous_config_reg[14] & self.rx.config_reg[14]) &
+                        ((preack_config_reg|0x4000) == (self.rx.config_reg|0x4000)),
                         rx_config_reg_ack.i.eq(1)
-                    ).Else(
-                        rx_config_reg.i.eq(1)
                     )
-                )
+                ),
+                # Record advertised ability of link partner
+                self.link_partner_adv_ability.eq(self.rx.config_reg)
             )
+        ]
+
+        # Speed detection via SGMII
+        sgmii_speed = Mux(is_sgmii,
+            self.link_partner_adv_ability[10:12], 0b10)
+        self.comb += [
+            is_sgmii.eq(self.link_partner_adv_ability[0]),
+            self.tx.sgmii_speed.eq(sgmii_speed),
+            self.rx.sgmii_speed.eq(sgmii_speed)
+        ]
+
+        # Detect that config_reg is empty
+        self.comb += [
+            config_reg_empty.eq((self.link_partner_adv_ability | 1) == 1)
         ]

--- a/misoc/test/test_pcs_1000basex.py
+++ b/misoc/test/test_pcs_1000basex.py
@@ -12,13 +12,6 @@ class TRXPaths(Module):
         self.comb += self.rx.decoder.input.eq(self.tx.encoder.output[0])
 
 
-class PCSLoopback(Module):
-    def __init__(self):
-        self.submodules.pcs = ClockDomainsRenamer({"eth_tx": "sys", "eth_rx": "sys"})(
-            PCS(check_period=16/125e6, more_ack_time=16/125e6))
-        self.comb += self.pcs.tbi_rx.eq(self.pcs.tbi_tx)
-
-
 class TestPCS(unittest.TestCase):
     def test_trxpaths_config(self):
         config_reg_values = [0x2341, 0x814e, 0x1ea8]
@@ -85,18 +78,3 @@ class TestPCS(unittest.TestCase):
 
                 run_simulation(dut, [transmit(), receive()])
                 self.assertEqual(received_packets, packets)
-
-    def test_pcs(self):
-        dut = PCSLoopback()
-
-        def test():
-            for i in range(8):
-                yield
-            link_up = yield dut.pcs.link_up
-            self.assertEqual(link_up, 0)
-            for i in range(50):
-                yield
-            link_up = yield dut.pcs.link_up
-            self.assertEqual(link_up, 1)
-
-        run_simulation(dut, test())


### PR DESCRIPTION
This pull request enables the existing 1000BASE-X PHY implementation to also support 10Mbps and 100Mbps via SGMII. This means the PHY can now automatically detect and operate in any of the following modes (tested on real testbench): 

* 1000Mbps, with 1000BASE-X transceiver
* 1000Mbps, with SGMII transceiver
* 100Mbps, with SGMII transceiver
* 10Mbps, with SGMII transceiver

For further explanation on the implementation, see the full commit message for c0cf664404b7abdbdb1a38e56bae34abdfdee50e.