### PR TITLE
Updating submodules configuration after llvm changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,11 +5,11 @@
 	path = misoc/cores/mor1kx/verilog
 	url = https://github.com/m-labs/mor1kx.git
 [submodule "misoc/software/compiler_rt"]
-	path = misoc/software/compiler_rt
-	url = http://llvm.org/git/compiler-rt.git
+    path = misoc/software/compiler_rt
+    url = https://github.com/llvm-mirror/compiler-rt.git
 [submodule "misoc/software/unwinder"]
 	path = misoc/software/unwinder
-	url = http://llvm.org/git/libunwind.git
+	url = https://github.com/llvm-mirror/libunwind.git
 [submodule "misoc/cores/vexriscv/verilog"]
 	path = misoc/cores/vexriscv/verilog
 	url = https://github.com/m-labs/VexRiscv-verilog.git


### PR DESCRIPTION
Updated the submodules for llvm `libunwind` and `compiler_rt`. 
Worth noticing that the submodules are now pointing at an archived version of the two repositories.
The live versions have been merged into:
[llvm-new](https://github.com/llvm/llvm-project)

