### PR TITLE
liteeth: Fix Kintex UltraScale GTH intermittent breakage

### DIFF
--- a/misoc/cores/liteeth_mini/phy/ku_1000basex.py
+++ b/misoc/cores/liteeth_mini/phy/ku_1000basex.py
@@ -65,10 +65,12 @@ class KU_1000BASEX(Module):
         tx_reset = Signal()
         tx_data = Signal(20)
         tx_reset_done = Signal()
+        tx_progdiv_reset = Signal()
 
         rx_reset = Signal()
         rx_data = Signal(20)
         rx_reset_done = Signal()
+        rx_progdiv_reset = Signal()
 
         xilinx_mess = dict(
             p_ACJTAG_DEBUG_MODE=0b0,
@@ -610,7 +612,7 @@ class KU_1000BASEX(Module):
             i_RXPOLARITY=0b0,
             i_RXPRBSCNTRESET=0b0,
             i_RXPRBSSEL=0b0000,
-            i_RXPROGDIVRESET=0b0,
+            i_RXPROGDIVRESET=rx_progdiv_reset,
             i_RXQPIEN=0b0,
             i_RXRATEMODE=0b0,
             i_RXRATE=0b000,
@@ -681,7 +683,7 @@ class KU_1000BASEX(Module):
             i_TXPRBSSEL=0b0000,
             i_TXPRECURSORINV=0b0,
             i_TXPRECURSOR=0b00000,
-            i_TXPROGDIVRESET=0b0,
+            i_TXPROGDIVRESET=tx_progdiv_reset,
             i_TXQPIBIASEN=0b0,
             i_TXQPISTRONGPDOWN=0b0,
             i_TXQPIWEAKPUP=0b0,
@@ -836,6 +838,11 @@ class KU_1000BASEX(Module):
         self.comb += [
             tx_reset.eq(pll_reset | ~pll_locked),
             rx_reset.eq(pll_reset | ~pll_locked | pcs.restart)
+        ]
+        # https://www.xilinx.com/support/answers/64103.html
+        self.comb += [
+            tx_progdiv_reset.eq(tx_reset),
+            rx_progdiv_reset.eq(rx_reset)
         ]
 
         # Gearbox and PCS connection


### PR DESCRIPTION
Fingers crossed, this PR should **finally, once and for all**, fix https://github.com/m-labs/artiq/issues/1424 where the Ethernet on the KU FPGA on Metlino would randomly break. The symptom can be any of the following:

* After replacing a working FPGA bitstream with another that only differs slightly (e.g. changing the ARTIQ version string in ROM, removing some unused EEM ports from the code), the new bitstream would cause the Ethernet to fail.
* After re-flashing with a new bitstream and reloading it to the FPGA, the Ethernet fails; after power-cycling, the Ethernet resumes to normal.
* After re-flashing with a new bitstream and reloading it to the FPGA, the Ethernet works normal; after power-cycling, the Ethernet fails.
* The Ethernet would randomly fail after each reloading (e.g. by `artiq_flash start`).

After consulting this [Xilinx page](https://www.xilinx.com/support/answers/62670.html), I believe the GTH is still missing some Xilinx parameters or signals, so I tweaked liteeth_mini's current usage of the GTH and tested. At the time of writing, I only needed to add the `PROGDIVRESET` signal such that both the GTH TX/RX and their programmable divisors are reset altogether, which should guarantee that the TX/RXOUTCLK aren't flatlined. And this has so far eliminated all the symptoms I described above.

It would be best to double check my logic and/or find more symptoms to test with, but I think this PR should be good enough. This has been tested on different units of Metlino, one in Hong Kong (M-Labs) and one in Poland (Creotech).