### PR TITLE
vexriscv: make bios big-endian

### DIFF
--- a/misoc/integration/builder.py
+++ b/misoc/integration/builder.py
@@ -168,13 +168,11 @@ class Builder:
                                      "bios.bin")
             with open(bios_file, "rb") as boot_file:
                 boot_data = []
-                unpack_endian = ">I" if self.soc.cpu_type != "vexriscv" else "<I"
                 while True:
                     w = boot_file.read(4)
                     if not w:
                         break
-                    boot_data.append(struct.unpack(unpack_endian, w)[0])
-
+                    boot_data.append(struct.unpack(">I", w)[0])
             self.soc.rom.mem.init = boot_data
 
     def build(self):

--- a/misoc/software/bios/Makefile
+++ b/misoc/software/bios/Makefile
@@ -11,6 +11,7 @@ all:: bios.bin
 	$(objcopy) -O binary
 ifeq ($(CPU_ENDIANNESS),LITTLE)
 	$(MSCIMG) $@ --little
+	objcopy -I binary -O binary --reverse-bytes=4 $@
 else
 	$(MSCIMG) $@
 endif


### PR DESCRIPTION
This PR is to convert the generated `bios.bin` to big-endian.

# Behavior before patch
A functioning gateware bitstream `top.bit` can be generated using `--integrated-rom-size` option (See #78).
However, booting at `0x400000` using `bios.bin` is not successful using `openocd` set in [artiq_flash](https://github.com/m-labs/artiq/blob/master/artiq/frontend/artiq_flash.py). Binary in big-endian is expected.

The little-endian binary of `bios.bin` is already converted into big-endian **in ~~ROM~~ `boot_data`** when building with `--integrated-rom-size` during memory initialization, in the following snippet:
https://github.com/m-labs/misoc/blob/dad351a66fbc8087a37bed0ce4b7bcf153e9795a/misoc/integration/builder.py#L171-L176

# Patch summary
## `software/bios/Makefile`
The `bios.bin` is flipped to big-endian when using a little-endian CPU (e.g. vexriscv).
## `integration/builder.py`
The endian swapping logic introduced in #78 (code snippet above) is reverted, as it is now being performed in `software/bios/Makefile` directly.
