### PR TITLE
vexriscv: use clang

### DIFF
--- a/misoc/integration/cpu_interface.py
+++ b/misoc/integration/cpu_interface.py
@@ -15,7 +15,7 @@ def get_cpu_mak(cpu):
     elif cpu == "vexriscv":
         triple = "riscv64-unknown-elf"
         cpuflags = "-D__vexriscv__ -march=rv32im  -mabi=ilp32"
-        clang = ""
+        clang = "1"
     elif cpu == "zynq7000":
         triple = "armv7-unknown-linux-gnueabihf"
         cpuflags = "-mfloat-abi=hard"


### PR DESCRIPTION
# One line summary
This patch enables the use of Clang to build VexRiscv target.
# Required Clang major version
- Clang 9 is needed to build with RISC-V target
- Clang 10 is needed to build with C flag `-mcmodel=medany`