### PR TITLE
VexRiscv: Update to support atomic instructions

### DIFF
--- a/misoc/cores/vexriscv/core.py
+++ b/misoc/cores/vexriscv/core.py
@@ -46,4 +46,4 @@ class VexRiscv(Module):
 
         # add Verilog sources
         vdir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "verilog")
-        platform.add_source(os.path.join(vdir, "VexRiscv.v"))
+        platform.add_source(os.path.join(vdir, "VexRiscv_IMA.v"))

--- a/misoc/software/include/base/csr-defs.h
+++ b/misoc/software/include/base/csr-defs.h
@@ -3,8 +3,8 @@
 
 #define CSR_MSTATUS_MIE 0x8
 
-#define CSR_IRQ_MASK 0x330
-#define CSR_IRQ_PENDING 0x360
+#define CSR_IRQ_MASK 0xBC0
+#define CSR_IRQ_PENDING 0xFC0
 
 #define CSR_DCACHE_INFO 0xCC0
 

--- a/misoc/software/libbase/system.c
+++ b/misoc/software/libbase/system.c
@@ -40,7 +40,7 @@ void flush_cpu_icache(void)
 		mtspr(SPR_ICBIR, i);
 #elif defined (__vexriscv__)
 	asm volatile(
-		".word(0x400F)\n"
+		"fence.i\n"
 		"nop\n"
 		"nop\n"
 		"nop\n"
@@ -76,13 +76,7 @@ void flush_cpu_dcache(void)
 	for (i = 0; i < cache_size; i += cache_block_size)
 		mtspr(SPR_DCBIR, i);
 #elif defined (__vexriscv__)
-	unsigned long cache_info;
-	asm volatile ("csrr %0, %1" : "=r"(cache_info) : "i"(CSR_DCACHE_INFO));
-	unsigned long cache_way_size = cache_info & 0xFFFFF;
-	unsigned long cache_line_size = (cache_info >> 20) & 0xFFF;
-	for(register unsigned long idx = 0;idx < cache_way_size;idx += cache_line_size){
-		asm volatile("mv x10, %0 \n .word(0b01110000000001010101000000001111)"::"r"(idx));
-	}
+	asm volatile(".word(0x500F)\n");
 #else
 #error Unsupported architecture
 #endif


### PR DESCRIPTION
# Summary
This PR changes the VecRiscv core to `VecRiscv_IMA.v` in `VexRiscv-verilog` master to support atomic instructions (`lr`/`sc` & `amo`). (See [this PR](https://github.com/m-labs/VexRiscv-verilog/pull/10) in `VexRiscv-verilog`.)
# Detail changes
- The `vexriscv/verilog` submodule is updated to include [this PR](https://github.com/m-labs/VexRiscv-verilog/pull/10).
- `vexriscv/core.py` now uses `VexRiscv_IMA.v`.
- Updated Machine IRQ Mask register and Machine IRQ Pending register defined in `csr-def.h`.
- Updated cache flushing instruction to `fence.i` and a custom instruction `.word(0x500F)`.
# Testing
BIOS can be built and run using the updated VexRiscv core.