### PR TITLE
ICAP: talk to ICAP primitive to restart gateware

### DIFF
--- a/misoc/cores/icap.py
+++ b/misoc/cores/icap.py
@@ -1,0 +1,152 @@
+from migen import *
+
+from misoc.interconnect.csr import AutoCSR, CSR
+
+class ICAP(Module, AutoCSR):
+    def __init__(self, platform):
+        """
+        ICAP module.
+
+        Use this module to issue the IPROG command and restart the gateware.
+        Both E2 and E3 are supported by selecting the right platform.
+        """
+        self.iprog = CSR()
+
+        ###
+
+        ICAP_WIDTH = "X32"
+        iprog_command_seq_i = [
+            0xFFFFFFFF, # 0: Dummy Word
+            0x000000BB, # 1: Bus Width Sync Word
+            0x11220044, # 2: Bus Width Detect Pattern
+            0xFFFFFFFF, # 3: Dummy Word
+            0x5599AA66, # 4: Sync Word
+            0x04000000, # 5: Type 1 NO OP 
+            0x0C400080, # 6: Write WBSTAR 
+            0x00000000, # 7: WBSTAR 
+            0x0C000180, # 8: Write CMD 
+            0x000000F0, # 9: Write IPROG 
+            0x04000000, # 10: Type 1 NO OP  
+            ]
+
+        o = Signal(32)      # 32-bit output: Configuration data output bus
+        csib = Signal()     # 1-bit input: Active-Low ICAP Enable
+        i = Signal(32)      # 32-bit input: Configuration data input bus
+        rdwrb = Signal()    # 1-bit input: Read/Write (1/0) Select input
+
+        # rising edge detection
+        edge = Signal(2)
+        self.sync += [
+            edge[1].eq(edge[0]),
+            edge[0].eq(self.iprog.re)
+        ]
+
+        fsm = FSM()
+        self.submodules += fsm
+        fsm.act(0,
+            NextValue(rdwrb, 1),
+            NextValue(csib, 1),
+            If(edge == 0b01,
+                NextState(1)
+            )
+        )
+        fsm.act(1,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 1),
+            NextState(2)
+        )
+        fsm.act(2,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextValue(i, iprog_command_seq_i[0]),
+            NextState(3)
+        )
+        fsm.act(3,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextValue(i, iprog_command_seq_i[1]),
+            NextState(4)
+        )
+        fsm.act(4,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextValue(i, iprog_command_seq_i[2]),
+            NextState(5)
+        )
+        fsm.act(5,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextValue(i, iprog_command_seq_i[3]),
+            NextState(6)
+        )
+        fsm.act(6,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextValue(i, iprog_command_seq_i[4]),
+            NextState(7)
+        )
+        fsm.act(7,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextValue(i, iprog_command_seq_i[5]),
+            NextState(8)
+        )
+        fsm.act(8,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextValue(i, iprog_command_seq_i[6]),
+            NextState(9)
+        )
+        fsm.act(9,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextValue(i, iprog_command_seq_i[7]),
+            NextState(10)
+        )
+        fsm.act(10,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextValue(i, iprog_command_seq_i[8]),
+            NextState(11)
+        )
+        fsm.act(11,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextValue(i, iprog_command_seq_i[9]),
+            NextState(12)
+        )
+        fsm.act(12,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextValue(i, iprog_command_seq_i[10]),
+            NextState(13)
+        )
+        fsm.act(13,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextState(14)
+        )
+        fsm.act(14,
+            NextValue(rdwrb, 0),
+            NextValue(csib, 0),
+            NextState(0)
+        )
+
+        if platform in {'kasli', 'phaser'}:
+            # ICAPE2 primitive module
+            self.specials += Instance("ICAPE2", name="ICAPE2_inst",
+                p_ICAP_WIDTH = ICAP_WIDTH,
+
+                i_CLK = ClockSignal(),
+                i_CSIB = csib,
+                i_I = i,
+                i_RDWRB = rdwrb
+                )
+        elif platform in {'metlino', 'sayma_amc'}:
+            # ICAPE3 primitive module
+            self.specials += Instance("ICAPE3", name="ICAPE3_inst",
+                i_CLK = ClockSignal(),
+                i_CSIB = csib,
+                i_I = i,
+                i_RDWRB = rdwrb
+                )

--- a/misoc/cores/icap.py
+++ b/misoc/cores/icap.py
@@ -79,13 +79,8 @@ class ICAP(Module, AutoCSR):
             icap_rdwrb.eq(1),
             icap_csib.eq(1),
             If(icap_iprog_re.o,
-                NextState("assert_write")
+                NextState("command")
             )
-        )
-        fsm.act("assert_write",
-            icap_rdwrb.eq(0),
-            icap_csib.eq(1),
-            NextState("command")
         )
         fsm.act("command",
             icap_rdwrb.eq(0),
@@ -93,15 +88,10 @@ class ICAP(Module, AutoCSR):
             icap_i.eq(iprog_command_seq[counter]),
             NextValue(counter, counter+1),
             If(counter == len(iprog_command_seq_i) - 1,
-                NextState("deactivate")
+                NextState("idle")
             ).Else(
                 NextState("command")
             )
-        )
-        fsm.act("deactivate",
-            icap_rdwrb.eq(0),
-            icap_csib.eq(1),
-            NextState("idle")
         )
 
         if fpga_family == "7series":

--- a/misoc/cores/icap.py
+++ b/misoc/cores/icap.py
@@ -15,7 +15,7 @@ class ICAP(Module, AutoCSR):
         ----------
         fpga_family : str
             FPGA family name, used to determine the version of primitive. 
-            Supported family: ultrascale (metlino/sayma), 7series (kasli)
+            Supported family: ultrascale (metlino), 7series (kasli/kc705)
 
         clk_divide_ratio : str
             Optional. The divide ratio of the clock frequency from system clock.

--- a/misoc/cores/icap.py
+++ b/misoc/cores/icap.py
@@ -13,9 +13,9 @@ class ICAP(Module, AutoCSR):
         
         Parameters
         ----------
-        flga_family : str
+        fpga_family : str
             FPGA family name, used to determine the version of primitive. 
-            Supported family: xcku040 (metlino/sayma), xc7a100t (kasli)
+            Supported family: ultrascale (metlino/sayma), 7series (kasli)
 
         clk_divide_ratio : str
             Optional. The divide ratio of the clock frequency from system clock.
@@ -23,7 +23,7 @@ class ICAP(Module, AutoCSR):
         self.iprog = CSR()
 
         ###
-        if fpga_family not in {"xcku040", "xc7a100t"}:
+        if fpga_family not in {"ultrascale", "7series"}:
             raise ValueError("Not supported FPGA family")
 
         iprog_command_seq_i = [
@@ -45,36 +45,34 @@ class ICAP(Module, AutoCSR):
         icap_i = Signal(32)      # 32-bit input: Configuration data input bus
         icap_rdwrb = Signal()    # 1-bit input: Read/Write (1/0) Select input
 
-        self.clock_domains.icap = ClockDomain()
+        self.clock_domains.cd_icap = ClockDomain(reset_less=True)
 
-        if fpga_family == "xc7a100t":
+        if fpga_family == "7series":
             # BUFR primitive module
             self.specials += Instance("BUFR",
                 p_BUFR_DIVIDE = clk_divide_ratio,
 
-                o_O = self.icap.clk,
+                o_O = self.cd_icap.clk,
                 i_CE = 1,
                 i_CLR = 0,
                 i_I = ClockSignal()
             )
-        elif fpga_family == "xcku040":
+        elif fpga_family == "ultrascale":
             # BUFGCE_DIV primitive module
             self.specials += Instance("BUFGCE_DIV",
                 p_BUFGCE_DIVIDE = int(clk_divide_ratio),
 
-                o_O = self.icap.clk,
+                o_O = self.cd_icap.clk,
                 i_CE = 1,
                 i_CLR = 0,
                 i_I = ClockSignal()
             )
 
         icap_iprog_re = PulseSynchronizer("sys", "icap")
-        self.comb += [
-            icap_iprog_re.i.eq(self.iprog.re),
-        ]
+        self.comb += icap_iprog_re.i.eq(self.iprog.re)
         self.submodules += icap_iprog_re
 
-        counter = Signal(max=11)
+        counter = Signal(max=len(iprog_command_seq_i))
         fsm = FSM(reset_state="idle")
         self.submodules += ClockDomainsRenamer("icap")(fsm)
         fsm.act("idle",
@@ -92,9 +90,9 @@ class ICAP(Module, AutoCSR):
         fsm.act("command",
             icap_rdwrb.eq(0),
             icap_csib.eq(0),
-            NextValue(icap_i, iprog_command_seq[counter]),
+            icap_i.eq(iprog_command_seq[counter]),
             NextValue(counter, counter+1),
-            If(counter == 10,
+            If(counter == len(iprog_command_seq_i) - 1,
                 NextState("deactivate")
             ).Else(
                 NextState("command")
@@ -106,7 +104,7 @@ class ICAP(Module, AutoCSR):
             NextState("idle")
         )
 
-        if fpga_family == "xc7a100t":
+        if fpga_family == "7series":
             # ICAPE2 primitive module
             self.specials += Instance("ICAPE2",
                 p_ICAP_WIDTH = "X32",
@@ -116,7 +114,7 @@ class ICAP(Module, AutoCSR):
                 i_I = icap_i,
                 i_RDWRB = icap_rdwrb
             )
-        elif fpga_family == "xcku040":
+        elif fpga_family == "ultrascale":
             # ICAPE3 primitive module
             self.specials += Instance("ICAPE3",
                 i_CLK = ClockSignal("icap"),

--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -150,7 +150,7 @@ class BaseSoC(SoCSDRAM):
             self.register_rom(self.spiflash.bus, 16*1024*1024)
             self.csr_devices.append("spiflash")
         
-        self.submodules.icap = icap.ICAP(version="E2")
+        self.submodules.icap = icap.ICAP("xc7a100t")
         self.csr_devices.append("icap")
 
 

--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -150,7 +150,7 @@ class BaseSoC(SoCSDRAM):
             self.register_rom(self.spiflash.bus, 16*1024*1024)
             self.csr_devices.append("spiflash")
         
-        self.submodules.icap = icap.ICAP("xc7a100t")
+        self.submodules.icap = icap.ICAP("7series")
         self.csr_devices.append("icap")
 
 

--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -150,7 +150,7 @@ class BaseSoC(SoCSDRAM):
             self.register_rom(self.spiflash.bus, 16*1024*1024)
             self.csr_devices.append("spiflash")
         
-        self.submodules.icap = icap.ICAP(platform='kasli')
+        self.submodules.icap = icap.ICAP(version="E2")
         self.csr_devices.append("icap")
 
 

--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -8,7 +8,7 @@ from migen.build.platforms.sinara import kasli
 
 from misoc.cores.sdram_settings import MT41K256M16
 from misoc.cores.sdram_phy import a7ddrphy
-from misoc.cores import virtual_leds, spi_flash
+from misoc.cores import virtual_leds, spi_flash, icap
 from misoc.cores.a7_gtp import *
 from misoc.cores.liteeth_mini.phy.a7_1000basex import A7_1000BASEX
 from misoc.cores.liteeth_mini.mac import LiteEthMAC
@@ -149,6 +149,9 @@ class BaseSoC(SoCSDRAM):
             self.flash_boot_address = 0x450000
             self.register_rom(self.spiflash.bus, 16*1024*1024)
             self.csr_devices.append("spiflash")
+        
+        self.submodules.icap = icap.ICAP(platform='kasli')
+        self.csr_devices.append("icap")
 
 
 class MiniSoC(BaseSoC):

--- a/misoc/targets/kc705.py
+++ b/misoc/targets/kc705.py
@@ -8,7 +8,7 @@ from migen.build.platforms import kc705
 
 from misoc.cores.sdram_settings import MT8JTF12864
 from misoc.cores.sdram_phy import k7ddrphy
-from misoc.cores import spi_flash
+from misoc.cores import spi_flash, icap
 from misoc.cores.liteeth_mini.phy import LiteEthPHY
 from misoc.cores.liteeth_mini.mac import LiteEthMAC
 from misoc.integration.soc_sdram import *
@@ -100,6 +100,8 @@ class BaseSoC(SoCSDRAM):
             self.flash_boot_address = 0xb40000
             self.register_rom(self.spiflash.bus, 16*1024*1024)
             self.csr_devices.append("spiflash")
+        self.submodules.icap = icap.ICAP("7series")
+        self.csr_devices.append("icap")
 
 
 class MiniSoC(BaseSoC):

--- a/misoc/targets/metlino.py
+++ b/misoc/targets/metlino.py
@@ -50,7 +50,7 @@ class BaseSoC(SoCSDRAM):
             self.register_rom(self.spiflash.bus, 16*1024*1024)
             self.csr_devices.append("spiflash")
         
-        self.submodules.icap = icap.ICAP(version="E3")
+        self.submodules.icap = icap.ICAP("xcku040")
         self.csr_devices.append("icap")
 
 

--- a/misoc/targets/metlino.py
+++ b/misoc/targets/metlino.py
@@ -50,7 +50,7 @@ class BaseSoC(SoCSDRAM):
             self.register_rom(self.spiflash.bus, 16*1024*1024)
             self.csr_devices.append("spiflash")
         
-        self.submodules.icap = icap.ICAP(platform='metlino')
+        self.submodules.icap = icap.ICAP(version="E3")
         self.csr_devices.append("icap")
 
 

--- a/misoc/targets/metlino.py
+++ b/misoc/targets/metlino.py
@@ -9,7 +9,7 @@ from migen.build.platforms.sinara import metlino
 
 from misoc.cores.sdram_settings import MT41J256M16
 from misoc.cores.sdram_phy import kusddrphy
-from misoc.cores import spi_flash
+from misoc.cores import spi_flash, icap
 from misoc.cores.liteeth_mini.phy.ku_1000basex import KU_1000BASEX
 from misoc.cores.liteeth_mini.mac import LiteEthMAC
 from misoc.integration.soc_sdram import *
@@ -49,6 +49,9 @@ class BaseSoC(SoCSDRAM):
             self.flash_boot_address = 0x50000
             self.register_rom(self.spiflash.bus, 16*1024*1024)
             self.csr_devices.append("spiflash")
+        
+        self.submodules.icap = icap.ICAP(platform='metlino')
+        self.csr_devices.append("icap")
 
 
 class MiniSoC(BaseSoC):

--- a/misoc/targets/metlino.py
+++ b/misoc/targets/metlino.py
@@ -50,7 +50,7 @@ class BaseSoC(SoCSDRAM):
             self.register_rom(self.spiflash.bus, 16*1024*1024)
             self.csr_devices.append("spiflash")
         
-        self.submodules.icap = icap.ICAP("xcku040")
+        self.submodules.icap = icap.ICAP("ultrascale")
         self.csr_devices.append("icap")
 
 


### PR DESCRIPTION
### Descritption of Changes
Added a new module that talks to ICAP. Only restart the gateware is implemented. Trigger the restart by writing a `1` to CSR ICAP iprog register.
Metlino and Kasli are supported at this time.