### PR TITLE
liteeth: Add little endian target support

### DIFF
--- a/misoc/cores/liteeth_mini/mac/__init__.py
+++ b/misoc/cores/liteeth_mini/mac/__init__.py
@@ -20,7 +20,7 @@ class LiteEthMAC(Module, AutoCSR):
             self.tx_slots = CSRConstant(ntxslots)
             self.slot_size = CSRConstant(2**bits_for(eth_mtu))
 
-            self.submodules.interface = LiteEthMACWishboneInterface(dw, nrxslots, ntxslots)
+            self.submodules.interface = LiteEthMACWishboneInterface(dw, nrxslots, ntxslots, endianness)
             self.comb += [
                 self.interface.source.connect(self.core.sink),
                 self.core.source.connect(self.interface.sink)

--- a/misoc/cores/liteeth_mini/mac/wishbone.py
+++ b/misoc/cores/liteeth_mini/mac/wishbone.py
@@ -9,7 +9,7 @@ from misoc.cores.liteeth_mini.mac import sram
 
 
 class LiteEthMACWishboneInterface(Module, AutoCSR):
-    def __init__(self, dw, nrxslots=2, ntxslots=2):
+    def __init__(self, dw, nrxslots=2, ntxslots=2, endianness="big"):
         self.sink = stream.Endpoint(eth_phy_layout(dw))
         self.source = stream.Endpoint(eth_phy_layout(dw))
         self.bus = wishbone.Interface()
@@ -18,7 +18,7 @@ class LiteEthMACWishboneInterface(Module, AutoCSR):
 
         # storage in SRAM
         sram_depth = eth_mtu//(dw//8)
-        self.submodules.sram = sram.LiteEthMACSRAM(dw, sram_depth, nrxslots, ntxslots)
+        self.submodules.sram = sram.LiteEthMACSRAM(dw, sram_depth, nrxslots, ntxslots, endianness)
         self.comb += [
             self.sink.connect(self.sram.sink),
             self.sram.source.connect(self.source)

--- a/misoc/targets/afc3v1.py
+++ b/misoc/targets/afc3v1.py
@@ -154,6 +154,7 @@ class MiniSoC(BaseSoC):
 
         self.submodules.ethmac = LiteEthMAC(
             phy=self.ethphy, dw=32, interface="wishbone",
+            endianness="little" if self.cpu_type == "vexriscv" else "big",
             nrxslots=2, ntxslots=2)
         ethmac_len = (ethmac_nrxslots + ethmac_ntxslots) * 0x800
         self.add_wb_slave(self.mem_map["ethmac"], ethmac_len, self.ethmac.bus)

--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -192,6 +192,7 @@ class MiniSoC(BaseSoC):
 
         self.submodules.ethmac = LiteEthMAC(
                 phy=self.ethphy, dw=32, interface="wishbone",
+                endianness="little" if self.cpu_type == "vexriscv" else "big",
                 nrxslots=ethmac_nrxslots, ntxslots=ethmac_ntxslots)
         ethmac_len = (ethmac_nrxslots + ethmac_ntxslots) * 0x800
         self.add_wb_slave(self.mem_map["ethmac"], ethmac_len, self.ethmac.bus)

--- a/misoc/targets/kc705.py
+++ b/misoc/targets/kc705.py
@@ -120,6 +120,7 @@ class MiniSoC(BaseSoC):
         self.submodules.ethphy = LiteEthPHY(eth_clocks,
                                             self.platform.request("eth"), clk_freq=self.clk_freq)
         self.submodules.ethmac = LiteEthMAC(phy=self.ethphy, dw=32, interface="wishbone",
+                                            endianness="little" if self.cpu_type == "vexriscv" else "big",
                                             nrxslots=ethmac_nrxslots, ntxslots=ethmac_ntxslots)
         ethmac_len = (ethmac_nrxslots + ethmac_ntxslots) * 0x800
         self.add_wb_slave(self.mem_map["ethmac"], ethmac_len, self.ethmac.bus)

--- a/misoc/targets/metlino.py
+++ b/misoc/targets/metlino.py
@@ -71,6 +71,7 @@ class MiniSoC(BaseSoC):
            self.platform.request("port0", 0),
            self.clk_freq)
         self.submodules.ethmac = LiteEthMAC(phy=self.ethphy, dw=32, interface="wishbone",
+                                            endianness="little" if self.cpu_type == "vexriscv" else "big",
                                             nrxslots=ethmac_nrxslots, ntxslots=ethmac_ntxslots)
         ethmac_len = (ethmac_nrxslots + ethmac_ntxslots) * 0x800
         self.add_wb_slave(self.mem_map["ethmac"], ethmac_len, self.ethmac.bus)

--- a/misoc/targets/mlabs_video.py
+++ b/misoc/targets/mlabs_video.py
@@ -138,7 +138,8 @@ class MiniSoC(BaseSoC):
         self.sync.base50 += eth_clocks.phy.eq(~eth_clocks.phy)
         self.submodules.ethphy = LiteEthPHY(eth_clocks,
                                             platform.request("eth"))
-        self.submodules.ethmac = LiteEthMAC(phy=self.ethphy, dw=32, interface="wishbone")
+        self.submodules.ethmac = LiteEthMAC(phy=self.ethphy, dw=32, interface="wishbone",
+                                            endianness="little" if self.cpu_type == "vexriscv" else "big")
         self.add_wb_slave(self.mem_map["ethmac"], 0x2000, self.ethmac.bus)
         self.add_memory_region("ethmac", self.mem_map["ethmac"] | self.shadow_base, 0x2000)
         self.csr_devices += ["ethphy", "ethmac"]

--- a/misoc/targets/sayma_amc.py
+++ b/misoc/targets/sayma_amc.py
@@ -155,6 +155,7 @@ class MiniSoC(BaseSoC):
            self.platform.request("sfp", 1),
            self.clk_freq)
         self.submodules.ethmac = LiteEthMAC(phy=self.ethphy, dw=32, interface="wishbone",
+                                            endianness="little" if self.cpu_type == "vexriscv" else "big",
                                             nrxslots=ethmac_nrxslots, ntxslots=ethmac_ntxslots)
         ethmac_len = (ethmac_nrxslots + ethmac_ntxslots) * 0x800
         self.add_wb_slave(self.mem_map["ethmac"], ethmac_len, self.ethmac.bus)

--- a/misoc/targets/simple.py
+++ b/misoc/targets/simple.py
@@ -35,6 +35,7 @@ class MiniSoC(BaseSoC):
                                             platform.request("eth"))
         self.submodules.ethmac = LiteEthMAC(phy=self.ethphy, dw=32,
                                             interface="wishbone",
+                                            endianness="little" if self.cpu_type == "vexriscv" else "big",
                                             with_preamble_crc=False)
         self.add_wb_slave(self.mem_map["ethmac"], 0x2000, self.ethmac.bus)
         self.add_memory_region("ethmac", self.mem_map["ethmac"] | self.shadow_base, 0x2000)


### PR DESCRIPTION
# Summary
This patch adds Ethernet support to little endian targets (VexRiscv in particular).

# Details
- Added little endian support to EthMac (with reference to [LiteEth](https://github.com/enjoy-digital/liteeth/commit/ce72e34f56ba3356aa79f9de2e50ed59ec405135)), to applicable targets, i.e.
  - `afc3v1.py`
  - `kasli.py`
  - `kc705.py`
  - `metlino.py`
  - `mlabs_video.py`
  - `sayma_amc.py`
  - `simple.py`