### PR TITLE
spi_flash: Add little endian support

### DIFF
--- a/misoc/integration/builder.py
+++ b/misoc/integration/builder.py
@@ -166,13 +166,14 @@ class Builder:
         if self.soc.integrated_rom_size:
             bios_file = os.path.join(self.output_dir, "software", "bios",
                                      "bios.bin")
+            unpack_endian = ">I" if self.soc.cpu_type != "vexriscv" else "<I"
             with open(bios_file, "rb") as boot_file:
                 boot_data = []
                 while True:
                     w = boot_file.read(4)
                     if not w:
                         break
-                    boot_data.append(struct.unpack(">I", w)[0])
+                    boot_data.append(struct.unpack(unpack_endian, w)[0])
             self.soc.rom.mem.init = boot_data
 
     def build(self):

--- a/misoc/software/bios/Makefile
+++ b/misoc/software/bios/Makefile
@@ -11,7 +11,6 @@ all:: bios.bin
 	$(objcopy) -O binary
 ifeq ($(CPU_ENDIANNESS),LITTLE)
 	$(MSCIMG) $@ --little
-	objcopy -I binary -O binary --reverse-bytes=4 $@
 else
 	$(MSCIMG) $@
 endif

--- a/misoc/targets/afc3v1.py
+++ b/misoc/targets/afc3v1.py
@@ -116,7 +116,9 @@ class BaseSoC(SoCSDRAM, AutoCSR):
             self.specials += Instance("STARTUPE2",
                                       i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
                                       i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
-            self.submodules.spiflash = spi_flash.SpiFlash(spiflash_pads, dummy=11, div=2)
+            self.submodules.spiflash = spi_flash.SpiFlash(
+                spiflash_pads, dummy=11, div=2,
+                endianness="little" if self.cpu_type == "vexriscv" else "big")
             self.config["SPIFLASH_PAGE_SIZE"] = 256
             self.config["SPIFLASH_SECTOR_SIZE"] = 0x10000
             self.csr_devices.append("spiflash")

--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -143,7 +143,9 @@ class BaseSoC(SoCSDRAM):
             self.specials += Instance("STARTUPE2",
                                       i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
                                       i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
-            self.submodules.spiflash = spi_flash.SpiFlash(spiflash_pads, dummy=5, div=2)
+            self.submodules.spiflash = spi_flash.SpiFlash(
+                spiflash_pads, dummy=5, div=2,
+                endianness="little" if self.cpu_type == "vexriscv" else "big")
             self.config["SPIFLASH_PAGE_SIZE"] = 256
             self.config["SPIFLASH_SECTOR_SIZE"] = 0x10000
             self.flash_boot_address = 0x450000

--- a/misoc/targets/kc705.py
+++ b/misoc/targets/kc705.py
@@ -94,7 +94,9 @@ class BaseSoC(SoCSDRAM):
             self.specials += Instance("STARTUPE2",
                                       i_CLK=0, i_GSR=0, i_GTS=0, i_KEYCLEARB=0, i_PACK=0,
                                       i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0, i_USRDONEO=1, i_USRDONETS=1)
-            self.submodules.spiflash = spi_flash.SpiFlash(spiflash_pads, dummy=11, div=2)
+            self.submodules.spiflash = spi_flash.SpiFlash(
+                spiflash_pads, dummy=11, div=2,
+                endianness="little" if self.cpu_type == "vexriscv" else "big")
             self.config["SPIFLASH_PAGE_SIZE"] = 256
             self.config["SPIFLASH_SECTOR_SIZE"] = 0x10000
             self.flash_boot_address = 0xb40000

--- a/misoc/targets/metlino.py
+++ b/misoc/targets/metlino.py
@@ -43,7 +43,9 @@ class BaseSoC(SoCSDRAM):
                                       i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0,
                                       i_FCSBO=1, i_FCSBTS=0,
                                       i_DO=0, i_DTS=0b1110)
-            self.submodules.spiflash = spi_flash.SpiFlash(spiflash_pads, dummy=11, div=2)
+            self.submodules.spiflash = spi_flash.SpiFlash(
+                spiflash_pads, dummy=11, div=2,
+                endianness="little" if self.cpu_type == "vexriscv" else "big")
             self.config["SPIFLASH_PAGE_SIZE"] = 256
             self.config["SPIFLASH_SECTOR_SIZE"] = 0x10000
             self.flash_boot_address = 0x50000

--- a/misoc/targets/papilio_pro.py
+++ b/misoc/targets/papilio_pro.py
@@ -81,8 +81,9 @@ class BaseSoC(SoCSDRAM):
                             sdram_module.geom_settings, sdram_module.timing_settings)
 
         if not self.integrated_rom_size:
-            self.submodules.spiflash = spi_flash.SpiFlash(platform.request("spiflash2x"),
-                                                          dummy=4, div=6)
+            self.submodules.spiflash = spi_flash.SpiFlash(
+                platform.request("spiflash2x"), dummy=4, div=6,
+                endianness="little" if self.cpu_type == "vexriscv" else "big")
             self.flash_boot_address = 0x70000
             self.register_rom(self.spiflash.bus)
             self.csr_devices.append("spiflash")

--- a/misoc/targets/pipistrello.py
+++ b/misoc/targets/pipistrello.py
@@ -117,8 +117,9 @@ class BaseSoC(SoCSDRAM):
                             sdram_module.geom_settings, sdram_module.timing_settings)
 
         if not self.integrated_rom_size:
-            self.submodules.spiflash = spi_flash.SpiFlash(platform.request("spiflash4x"),
-                                                          dummy=10, div=4)
+            self.submodules.spiflash = spi_flash.SpiFlash(
+                platform.request("spiflash4x"), dummy=10, div=4,
+                endianness="little" if self.cpu_type == "vexriscv" else "big")
             self.config["SPIFLASH_PAGE_SIZE"] = 256
             self.config["SPIFLASH_SECTOR_SIZE"] = 0x10000
             self.flash_boot_address = 0x220000

--- a/misoc/targets/qm_xc6slx16_sdram.py
+++ b/misoc/targets/qm_xc6slx16_sdram.py
@@ -80,8 +80,9 @@ class BaseSoC(SoCSDRAM):
         self.register_sdram(self.sdrphy, "minicon",
                             sdram_module.geom_settings, sdram_module.timing_settings)
 
-        self.submodules.spiflash = spi_flash.SpiFlash(platform.request("spiflash"),
-                                                          dummy=8, div=2)
+        self.submodules.spiflash = spi_flash.SpiFlash(
+            platform.request("spiflash"), dummy=8, div=2,
+            endianness="little" if self.cpu_type == "vexriscv" else "big")
         self.register_mem("spiflash", 0x70000000, 0x1000000, self.spiflash.bus)
         self.flash_boot_address = 0x70080000
 

--- a/misoc/targets/sayma_amc.py
+++ b/misoc/targets/sayma_amc.py
@@ -128,7 +128,9 @@ class BaseSoC(SoCSDRAM):
                                       i_USRCCLKO=spiflash_pads.clk, i_USRCCLKTS=0,
                                       i_FCSBO=1, i_FCSBTS=0,
                                       i_DO=0, i_DTS=0b1110)
-            self.submodules.spiflash = spi_flash.SpiFlash(spiflash_pads, dummy=11, div=2)
+            self.submodules.spiflash = spi_flash.SpiFlash(
+                spiflash_pads, dummy=11, div=2,
+                endianness="little" if self.cpu_type == "vexriscv" else "big")
             self.config["SPIFLASH_PAGE_SIZE"] = 256
             self.config["SPIFLASH_SECTOR_SIZE"] = 0x10000
             self.flash_boot_address = 0x50000


### PR DESCRIPTION
# Changes
- Revert #111.
- Add little endian support to SPI flash ([reference from litex](https://github.com/enjoy-digital/litex/commit/468780c045da1222290bde69496852d5d3ee6e43#diff-dc7860dd5fd69b405989e6df5e77ef00695f8562b3590e6e5dc348aced2f3b3d)) for the following targets:
  - afc3v1
  - kasli
  - kc705
  - metlino
  - papilio_pro
  - pipistrello
  - qm_xc6slx16_sdram (spi_flash seems broken there? It does not have the `dq` subsignal in the platform)
  - sayma_amc

# Issue with flashing a byte-swapped binary
#111 byte-swaps the BIOS binary into little-endian, if the target CPU was configured with `vexriscv`.
Although it ensure the instructions read from SPI flash is with the correct endianness, configuring the flash becomes messy.
## Configure for read
This can be demonstrated with reference to `artiq_mkfs`, suppose we have an entry of `{"foo": "1"}` in the flash with swapped endianness.
```
00000000  00 00 00 09 66 6f 6f 00  31 ff ff ff ff           |....foo.1....|
0000000d
```
A little endian machine will interpret this as a slice with the wrong byte order.

One solution is to byte-swap the entire binary before flash (e.g. modify `artiq_mkfs.py`). It is a somewhat clean solution as long as the flash content need not be modified, which brings us into the next part.
## Modifying the flash
To make our `{"foo": "1"}` understandable by Rust (or other platforms), the bytes needs to be rewritten into the following hexdump.
```
00000000  09 00 00 00 00 6f 6f 66  ff ff ff 31 ff           |.....oof...1.|
0000000d
```
(Note: The terminating `0xff`s might need to be padded to align with 16 bytes, but for the sake of simplicity, let's ignore the termination all together.)
Suppose the flash is to be modified on runtime, e.g. append one more entry `{"bar": "2"}`. One naive solution is to write the binary representation from address `0x0a` onward, the following might be the result.
```
00000000  09 00 00 00 00 6f 6f 66  ff 00 00 00 09 62 61 72          |.....oof.....bar|
...
```
(With the encoding beyond `"bar"` omitted, this should give a clear enough picture.)

Modifying existing code to fit this case is totally doable. However, adding little endian support to the SPI flash would be a cleaner solution.

# Notes
I think there are too many "set little-endian if it uses vexriscv, otherwise big-endian" statements (including previous patches e.g. #117), should we refactor the endianness argument at some point?