### PR TITLE
(fd)libm: add RISC-V target to the list of little endian targets

### DIFF
--- a/misoc/software/include/fdlibm/fdlibm.h
+++ b/misoc/software/include/fdlibm/fdlibm.h
@@ -15,7 +15,7 @@
 
 #if defined(i386) || defined(i486) || \
   defined(intel) || defined(x86) || defined(i86pc) || \
-  defined(__alpha) || defined(__osf__)
+  defined(__alpha) || defined(__osf__) || defined(__riscv)
 #define __LITTLE_ENDIAN
 #endif
 


### PR DESCRIPTION
# Change
libm now uses the little endian version of macros in `fdlibm.h` (e.g. `__HI`, `__LO`) for RISC-V target.