### PR TITLE
VexRiscv: Add Rust, LLVM support

### DIFF
--- a/misoc/integration/cpu_interface.py
+++ b/misoc/integration/cpu_interface.py
@@ -8,25 +8,30 @@ def get_cpu_mak(cpu):
         triple = "lm32-elf"
         cpuflags = "-mbarrel-shift-enabled -mmultiply-enabled -mdivide-enabled -msign-extend-enabled"
         clang = ""
+        llvm_tools = ""
     elif cpu == "or1k":
         triple = "or1k-linux"
         cpuflags = "-mhard-mul -mhard-div -mror -mffl1 -maddc"
         clang = "1"
+        llvm_tools = ""
     elif cpu == "vexriscv":
         triple = "riscv32-unknown-linux"
         cpuflags = "-D__vexriscv__ -march=rv32ima -mabi=ilp32"
         clang = "1"
+        llvm_tools = "1"
     elif cpu == "zynq7000":
         triple = "armv7-unknown-linux-gnueabihf"
         cpuflags = "-mfloat-abi=hard"
         clang = "1"
+        llvm_tools = "1"
     else:
         raise ValueError("Unsupported CPU type: "+cpu)
     return [
         ("TRIPLE", triple),
         ("CPU", cpu),
         ("CPUFLAGS", cpuflags),
-        ("CLANG", clang)
+        ("CLANG", clang),
+        ("LLVM_TOOLS", llvm_tools)
     ]
 
 

--- a/misoc/integration/cpu_interface.py
+++ b/misoc/integration/cpu_interface.py
@@ -13,8 +13,8 @@ def get_cpu_mak(cpu):
         cpuflags = "-mhard-mul -mhard-div -mror -mffl1 -maddc"
         clang = "1"
     elif cpu == "vexriscv":
-        triple = "riscv64-unknown-elf"
-        cpuflags = "-D__vexriscv__ -march=rv32im  -mabi=ilp32"
+        triple = "riscv32-unknown-linux"
+        cpuflags = "-D__vexriscv__ -march=rv32ima -mabi=ilp32"
         clang = "1"
     elif cpu == "zynq7000":
         triple = "armv7-unknown-linux-gnueabihf"

--- a/misoc/software/common.mak
+++ b/misoc/software/common.mak
@@ -17,9 +17,17 @@ else
 CC_normal      := $(TARGET_PREFIX)gcc -std=gnu99
 CX_normal      := $(TARGET_PREFIX)g++
 endif
+
+ifeq ($(LLVM_TOOLS),1)
+AR_normal      := llvm-ar
+LD_normal      := ld.lld
+OBJCOPY_normal := llvm-objcopy
+else
 AR_normal      := $(TARGET_PREFIX)ar
 LD_normal      := $(TARGET_PREFIX)ld
 OBJCOPY_normal := $(TARGET_PREFIX)objcopy
+endif
+
 MSCIMG_normal  := $(PYTHON) -m misoc.tools.mkmscimg
 
 ifeq ($(CPU),or1k)
@@ -78,7 +86,10 @@ export CC_$(subst -,_,$(CARGO_TRIPLE)) = clang
 export CFLAGS_$(subst -,_,$(CARGO_TRIPLE)) = $(CFLAGS)
 
 # Linker options
-LDFLAGS = --gc-sections -nostdlib -nodefaultlibs -L$(BUILDINC_DIRECTORY)
+LDFLAGS = --gc-sections -nostdlib -L$(BUILDINC_DIRECTORY)
+ifneq ($(LLVM_TOOLS),1)
+	LDFLAGS += -nodefaultlibs
+endif
 
 ifeq ($(CPU),vexriscv)
 	CPU_ENDIANNESS = LITTLE


### PR DESCRIPTION
# Summary
The patch enables VexRiscv target to build in Rust using the builtin `riscv32imac-unknown-none-elf` target, while converting the built tools of VexRiscv from binutils to ld.lld and llvm-bintools. The purpose is to support the RISC-V port of ARTIQ.

# Detail of changes
## VexRiscv target configuration
- The triple is changed to `riscv32-unknown-linux` to emphasize that the CPU target is 32-bits RISC-V. The `linux` sys is specified to ensure that the `-shared` flag is implemented properly for compiling shared libraries (see ARTIQ).
## Rust support for VexRiscv
### `common.mak`
- `CARGO_TRIPLE` and `CARGO_NORMAL` is now gated by the CPU type, only `or1k` and `vexriscv` will have both defined.
- The Rust builtin target `riscv32imac-unknown-none-elf` is supported when building with `vexriscv`, with the compression feature (`c`) disabled.
- The unstable flag `build-std=core,alloc` is added to built Rust standard libraries with the above feature modification (used to be performed by xargo/cargo-xbuild, but now unstable Rust supports it).
### `integration/sdram_init.py`
- Uses `llvm_asm!` for `riscv32` architecture in Rust, and `asm!` for `or1k` target for backward compatibility.

## Changing build tools to ld.lld + llvm-bintools
- `cpu_interface`: Added the `llvm_tools` option. Enabled in `vexriscv`.
- `common.mak`: It now checks the `LLVM_TOOLS` flag. When enabled, misoc will build the binary using `llvm-ar`, `llvm-objcopy` and `ld.lld` instead of GNU binutils.