### PR TITLE
vexriscv: Build Rust library with cargo-xbuild

### DIFF
--- a/misoc/software/common.mak
+++ b/misoc/software/common.mak
@@ -7,7 +7,7 @@ ifeq ($(CPU),or1k)
 	CARGO_TRIPLE=$(subst or1k-linux,or1k-unknown-none,$(TRIPLE))
 endif
 ifeq ($(CPU),vexriscv)
-	CARGO_TRIPLE=$(subst riscv32-unknown-linux,riscv32imac-unknown-none-elf,$(TRIPLE))
+	CARGO_TRIPLE=$(subst riscv32-unknown-linux,riscv32ima-unknown-none-elf,$(TRIPLE))
 endif
 
 ifeq ($(CLANG),1)
@@ -34,7 +34,7 @@ ifeq ($(CPU),or1k)
 CARGO_normal   := env CARGO_TARGET_DIR=$(realpath .)/cargo cargo rustc --target $(CARGO_TRIPLE)
 endif
 ifeq ($(CPU),vexriscv)
-CARGO_normal   := env CARGO_TARGET_DIR=$(realpath .)/cargo cargo rustc -Z build-std=core,alloc --target $(CARGO_TRIPLE)
+CARGO_normal   := cargo xbuild
 endif
 
 CC_quiet      = @echo " CC      " $@ && $(CC_normal)


### PR DESCRIPTION
# Changes
- Updated Rust target triple to `riscv32ima-unknown-none-elf`, to match the changes in ARTIQ RISC-V.
- Build Rust library using `cargo xbuild` instead of `cargo rustc` with the unstable feature `build-std`