### PR TITLE
SoCCore: Re-expose CSR address width parameter

### DIFF
--- a/misoc/integration/soc_core.py
+++ b/misoc/integration/soc_core.py
@@ -24,7 +24,7 @@ class SoCCore(Module):
                 integrated_sram_size=4096,
                 integrated_main_ram_size=16*1024,
                 shadow_base=0x80000000,
-                csr_data_width=8,
+                csr_data_width=8, csr_address_width=14,
                 with_uart=True, uart_baudrate=115200,
                 ident="",
                 with_timer=True):
@@ -89,7 +89,7 @@ class SoCCore(Module):
         self.config["DATA_WIDTH_BYTES"] = self.cpu_dw//8
 
         self.csr_data_width = csr_data_width
-        self.csr_address_width = 16 - log2_int(self.cpu_dw//8)
+        self.csr_address_width = csr_address_width
 
         self._wb_slaves = WishboneSlaveManager(self.shadow_base, dw=self.cpu_dw)
 
@@ -108,7 +108,7 @@ class SoCCore(Module):
 
         self.submodules.wishbone2csr = wishbone2csr.WB2CSR(
             bus_csr=csr_bus.Interface(self.csr_data_width, self.csr_address_width), wb_bus_dw=self.cpu_dw)
-        self.register_mem("csr", self.mem_map["csr"], 64*1024, self.wishbone2csr.wishbone)
+        self.register_mem("csr", self.mem_map["csr"], (self.cpu_dw//8)*2**self.csr_address_width, self.wishbone2csr.wishbone)
 
         if with_uart:
             self.submodules.uart_phy = uart.RS232PHY(platform.request("serial"), clk_freq, uart_baudrate)


### PR DESCRIPTION
This patch is to revert the changes made to CSR address width calculation in 4f66420 for backward-compatibility.
4f66420 does automatic calculation of the required address width for the CSRs, assuming the CSR memory region always takes up 64KB.
However, some targets (e.g. [metlino in ARTIQ](https://github.com/m-labs/artiq/blob/master/artiq/gateware/targets/metlino.py)) needs a larger address space to support more CSR regions. Just as pre- 4f66420, assigning a larger `csr_address_width` can solve the issue.

If the effect of 4f66420 is desired, simply set `csr_address_width=13` when passing `cpu_bus_width=64` to `SoCCore`.