### PR TITLE
cpu_interface: add dmb() support

### DIFF
--- a/misoc/integration/cpu_interface.py
+++ b/misoc/integration/cpu_interface.py
@@ -187,7 +187,7 @@ def _get_rstype(size):
         return "u8"
 
 
-def _get_rw_functions_rs(reg_name, reg_base, size, nwords, busword, read_only, cpu_dw_bytes, use_dmb=False):
+def _get_rw_functions_rs(reg_name, reg_base, size, nwords, busword, read_only, cpu_dw_bytes):
     r = ""
 
     r += "    pub const "+reg_name.upper()+"_ADDR: *mut u32 = "+hex(reg_base)+" as *mut u32;\n"
@@ -202,13 +202,13 @@ def _get_rw_functions_rs(reg_name, reg_base, size, nwords, busword, read_only, c
     r += "    pub unsafe fn "+reg_name+"_read() -> "+rstype+" {\n"
     if nwords > 1:
         r += "      let r = read_volatile("+rsname+") as "+rstype+";\n"
-        if use_dmb:
-            r += "      dmb();\n"
+        r += "      #[cfg(target_arch = \"arm\")]"
+        r += "      dmb();\n"
         for word in range(1, nwords):
             r += "      let r = r << "+str(busword)+" | " + \
                  "read_volatile("+rsname+".offset("+str(word*(cpu_dw_bytes//4))+")) as "+rstype+";\n"
-            if use_dmb:
-                r += "      dmb();\n"
+            r += "      #[cfg(target_arch = \"arm\")]"
+            r += "      dmb();\n"
         r += "      r\n"
     else:
         r += "      read_volatile("+rsname+") as "+rstype+"\n"
@@ -236,7 +236,7 @@ def _region_by_name(regions, search_name):
     raise KeyError
 
 
-def get_csr_rust(regions, groups, constants, cpu_dw_bytes=4, use_dmb=False):
+def get_csr_rust(regions, groups, constants, cpu_dw_bytes=4):
     r = "#[allow(dead_code)]\n"
     r += "pub mod csr {\n"
 
@@ -247,14 +247,14 @@ def get_csr_rust(regions, groups, constants, cpu_dw_bytes=4, use_dmb=False):
             r += "  pub mod "+name+" {\n"
             r += "    #[allow(unused_imports)]\n"
             r += "    use core::ptr::{read_volatile, write_volatile};\n"
-            if use_dmb:
-                r += "    #[allow(unused_imports)]\n"
-                r += "    use libcortex_a9::asm::dmb;\n"
+            r += "    #[cfg(target_arch = \"arm\")]"
+            r += "    #[allow(unused_imports)]\n"
+            r += "    use libcortex_a9::asm::dmb;\n"
             r += "\n"
             for csr in obj:
                 nwords = (csr.size + busword - 1)//busword
                 r += _get_rw_functions_rs(csr.name, origin, csr.size, nwords, busword,
-                                          is_readonly(csr), cpu_dw_bytes, use_dmb)
+                                          is_readonly(csr), cpu_dw_bytes)
                 origin += cpu_dw_bytes*nwords
             r += "  }\n\n"
 


### PR DESCRIPTION
As discussed in https://git.m-labs.hk/M-Labs/artiq-zynq/pulls/176 - to prevent AXI bursts from being issued on CSR for Zynq-based systems, this adds ``dmb()`` calls for between memory accesses for registers bigger than 32 bits.

This patch adds this feature without breaking compatibility.

Unfortunately this needs to rely on ``libcortex_a9`` - cannot just call ``llvm_asm`` as that requires corresponding feature enabled in the crate (not file).

Few things come to mind now - since it's limited to only one platform, maybe CPU type should be also passed? Or the argument could be called ``use_cortexa9_dmb`` instead?