### PR TITLE
[WIP] SYS/RTIO clock merge

### DIFF
--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -52,25 +52,24 @@ class _CRG(Module, AutoCSR):
         clk125 = platform.request("clk125_gtp")
         platform.add_period_constraint(clk125, 8.)
         self.clk125_buf = Signal()
-        #self.clk125_div2 = Signal()
         self.specials += Instance("IBUFDS_GTE2",
             i_CEB=0,
             i_I=clk125.p, i_IB=clk125.n,
             o_O=self.clk125_buf)
-            # o_ODIV2=self.clk125_div2)
 
-        # old "rtio" clock
+        # "rtio" clock (mgt flavor)
         if platform.hw_rev == "v2.0":
-            si5324_out = platform.request("cdr_clk_clean_fabric")
+            si5324_out = platform.request("cdr_clk_clean")
         else:
-            si5324_out = platform.request("si5324_clkout_fabric")
+            si5324_out = platform.request("si5324_clkout")
+         
         si5324_buf = Signal()
         platform.add_period_constraint(si5324_out, 8.0)
-        self.specials += [
-            Instance("IBUFGDS",
-                p_DIFF_TERM="TRUE", p_IBUF_LOW_PWR="FALSE",
-                i_I=si5324_out.p, i_IB=si5324_out.n, o_O=si5324_buf),
-        ]
+
+        self.specials += Instance("IBUFDS_GTE2",
+            i_CEB=0,
+            i_I=si5324_out.p, i_IB=si5324_out.n,
+            o_O=si5324_buf)
 
         chosen_clk = Signal()
 

--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -102,7 +102,7 @@ class _CRG(Module, AutoCSR):
         pll_clk200 = Signal()
         self.specials += [
             Instance("MMCME2_BASE",
-                # what if si5324 output is 100 or 150MHz?
+                # 100/150mhz si5324 output not supported
                 p_CLKIN1_PERIOD=16.0,
                 i_CLKIN1=chosen_clk_div2,
 
@@ -111,8 +111,8 @@ class _CRG(Module, AutoCSR):
                 o_LOCKED=mmcm_locked,
 
                 # VCO @ 1GHz with MULT=16 (62.5MHz)
-                # why 14.5 then?
-                p_CLKFBOUT_MULT_F=14.5, p_DIVCLK_DIVIDE=1,
+                # why was it 14.5 then?
+                p_CLKFBOUT_MULT_F=16.0, p_DIVCLK_DIVIDE=1,
 
                 # ~125MHz
                 p_CLKOUT0_DIVIDE_F=8.0, p_CLKOUT0_PHASE=0.0, o_CLKOUT0=mmcm_sys,

--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -43,19 +43,19 @@ class _CRG(Module, AutoCSR):
         self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
         self.clock_domains.cd_clk200 = ClockDomain()
 
-        self.clk125_buf = Signal()
-
         self.clock_sel = CSRStorage()
         self.pll_locked = CSRStatus()
 
         # old "sys" clock, now bootstrap
         clk125 = platform.request("clk125_gtp")
         platform.add_period_constraint(clk125, 8.)
-        self.clk125_buf = Signal()
+        clk125_buf = Signal()
+        clk125_div2 = Signal()
         self.specials += Instance("IBUFDS_GTE2",
             i_CEB=0,
             i_I=clk125.p, i_IB=clk125.n,
-            o_O=self.clk125_buf)
+            o_O=clk125_buf,
+            o_ODIV2=clk125_div2)
 
         # "rtio" clock (mgt flavor)
         if platform.hw_rev == "v2.0":
@@ -64,20 +64,33 @@ class _CRG(Module, AutoCSR):
             si5324_out = platform.request("si5324_clkout")
          
         si5324_buf = Signal()
-        platform.add_period_constraint(si5324_out, 8.0)
+        si5324_div2 = Signal()
+        platform.add_period_constraint(si5324_out, 8.)
+
+        disable_cdr_clk_ibuf = Signal(reset=1)
+        disable_cdr_clk_ibuf.attr.add("no_retiming")
 
         self.specials += Instance("IBUFDS_GTE2",
-            i_CEB=0,
+            i_CEB=1,
             i_I=si5324_out.p, i_IB=si5324_out.n,
-            o_O=si5324_buf)
+            o_O=si5324_buf,
+            o_ODIV2=si5324_div2)
 
-        chosen_clk = Signal()
+        self.chosen_clk = Signal()
+        self.chosen_clk_div2 = Signal()
 
-        self.specials += Instance("BUFGMUX",
-                i_I0=self.clk125_buf,
+        self.specials += [ 
+            Instance("BUFGMUX",
+                i_I0=clk125_buf,
                 i_I1=si5324_buf,
-                o_O=chosen_clk,
-                i_S = self.clock_sel.storage),
+                o_O=self.chosen_clk,
+                i_S=self.clock_sel.storage),
+            Instance("BUFGMUX",
+                i_I0=clk125_div2,
+                i_I1=si5324_div2,
+                o_O=self.chosen_clk_div2,
+                i_S=self.clock_sel.storage)
+        ]
             
         mmcm_locked = Signal()
         mmcm_fb = Signal()
@@ -90,19 +103,19 @@ class _CRG(Module, AutoCSR):
         self.specials += [
             Instance("MMCME2_BASE",
                 # what if si5324 output is 100 or 150MHz?
-                p_CLKIN1_PERIOD=8.0,
-                i_CLKIN1=chosen_clk,
+                p_CLKIN1_PERIOD=16.0,
+                i_CLKIN1=self.chosen_clk_div2,
 
                 i_CLKFBIN=mmcm_fb,
                 o_CLKFBOUT=mmcm_fb,
                 o_LOCKED=mmcm_locked,
 
                 # VCO @ 1GHz with MULT=16 (62.5MHz)
-                # why was it 14.5 then?
+                # why 14.5 then?
+                p_CLKFBOUT_MULT_F=14.5, p_DIVCLK_DIVIDE=1,
 
                 # VCO @ 1GHz with MULT = 8 (non-divided 125MHz)
-                p_CLKFBOUT_MULT_F=8, p_DIVCLK_DIVIDE=1,
-
+               
                 # ~125MHz
                 p_CLKOUT0_DIVIDE_F=8.0, p_CLKOUT0_PHASE=0.0, o_CLKOUT0=mmcm_sys,
 
@@ -111,15 +124,15 @@ class _CRG(Module, AutoCSR):
                 p_CLKOUT2_DIVIDE=2, p_CLKOUT2_PHASE=90.0, o_CLKOUT2=mmcm_sys4x_dqs,
             ),
             Instance("PLLE2_BASE",
-                p_CLKIN1_PERIOD=8.0,
-                i_CLKIN1=chosen_clk,
+                p_CLKIN1_PERIOD=16.0,
+                i_CLKIN1=self.chosen_clk_div2,
 
                 i_CLKFBIN=pll_fb,
                 o_CLKFBOUT=pll_fb,
                 o_LOCKED=pll_locked,
 
                 # VCO @ 1GHz
-                p_CLKFBOUT_MULT=8, p_DIVCLK_DIVIDE=1,
+                p_CLKFBOUT_MULT=16, p_DIVCLK_DIVIDE=1,
 
                 # 200MHz for IDELAYCTRL
                 p_CLKOUT0_DIVIDE=5, p_CLKOUT0_PHASE=0.0, o_CLKOUT0=pll_clk200,
@@ -242,7 +255,7 @@ class MiniSoC(BaseSoC):
             fbdiv=4,
             fbdiv_45=5,
             refclk_div=1)
-        qpll = QPLL(self.crg.clk125_buf, qpll_settings)
+        qpll = QPLL(self.crg.chosen_clk, qpll_settings)
         self.submodules += qpll
         self.ethphy_qpll_channel = qpll.channels[0]
 


### PR DESCRIPTION
So for Kasli we'd like to use the RTIO clock (output of Si5324) as SYS clock, avoiding clock domain transfers, with a simple bootstrap clock before the bootloader changes the clock. It seems possible in general, but comes with its own challenges - e.g. no support for 100/150MHz clocks (unless we set the MMCM/PLL parameters to match these frequencies? change in gateware + software, essentially, different build).

Marking this PR as WIP as I've been having difficulties with it and it's nowhere near finished. There's also kc705 support in there to be done as well, and I suppose it should be eventually merged in tandem with ARTIQ part.

Few things that I encountered though that I would like an explanation for:
- why is the div2 clock used in MMCM/PLL, rather than the 125MHz one?
- why was sysclk running at ~114MHz instead of 125 (see clkfbout_mult_f @ 14.5 instead of 16)? this looks like an oversight?
- Kasli QPLL took the buffered 125MHz from the reference directly (see line 209/256 of kasli.py) - I cannot use the "chosen clock" from BUFGMUX, as Vivado complains about unbuffered output, and sending the BUFGMUX output through BUFG/BUFH/BUFR resulted in unroutable design. Which should it use, is there a way to choose a clock for it too?

At the point of making this PR this method doesn't meet timing constraints and I can't seem to find a way to improve it (e.g. putting the si5324 clock through MMCM and then to BUFGMUX makes it even worse). Unless there's a different, better way to switch between the two clocks (probably is). I managed to run it at some point, but more by luck I suppose. I get garbage output on serial most of the time, possibly due to unmet timing, quite badly too. 
```
------------------------------------------------------------------------------------------------
| Design Timing Summary
| ---------------------
------------------------------------------------------------------------------------------------

    WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total Endpoints      WHS(ns)      THS(ns)  THS Failing Endpoints  THS Total Endpoints     WPWS(ns)     TPWS(ns)  TPWS Failing Endpoints  TPWS Total Endpoints  
    -------      -------  ---------------------  -------------------      -------      -------  ---------------------  -------------------     --------     --------  ----------------------  --------------------  
     -3.074       -5.992                      2                36450        0.056        0.000                      0                36446        0.264        0.000                       0                 15627  


Timing constraints are not met.
```

Open for suggestions, changes, criticism.