### PR TITLE
Configuration of IBUFDS_GTE2 was updated.

### DIFF
--- a/misoc/targets/afc3v1.py
+++ b/misoc/targets/afc3v1.py
@@ -35,7 +35,10 @@ class _CRG(Module):
                                   i_CEB=0,
                                   i_I=clk125.p, i_IB=clk125.n,
                                   o_O=self.clk125_buf,
-                                  o_ODIV2=clk125_div2)
+                                  o_ODIV2=clk125_div2,
+                                  p_CLKCM_CFG="TRUE",
+                                  p_CLKRCV_TRST="TRUE",
+                                  p_CLKSWING_CFG=3)
 
         self.mmcm_locked = mmcm_locked = Signal()
         mmcm_fb = Signal()

--- a/misoc/targets/efc.py
+++ b/misoc/targets/efc.py
@@ -113,7 +113,10 @@ class _RtioSysCRG(Module, AutoCSR):
             i_CEB=0,
             i_I=clk125.p, i_IB=clk125.n,
             o_O=self.clk125_buf,
-            o_ODIV2=self.clk125_div2)
+            o_ODIV2=self.clk125_div2,
+            p_CLKCM_CFG="TRUE",
+            p_CLKRCV_TRST="TRUE",
+            p_CLKSWING_CFG=3)
 
         self.submodules.clk_sw_fsm = ClockSwitchFSM()
 
@@ -229,7 +232,10 @@ class _SysCRG(Module):
             i_CEB=0,
             i_I=clk125.p, i_IB=clk125.n,
             o_O=self.clk125_buf,
-            o_ODIV2=self.clk125_div2)
+            o_ODIV2=self.clk125_div2,
+            p_CLKCM_CFG="TRUE",
+            p_CLKRCV_TRST="TRUE",
+            p_CLKSWING_CFG=3)
 
         mmcm_locked = Signal()
         mmcm_fb = Signal()

--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -115,7 +115,10 @@ class _RtioSysCRG(Module, AutoCSR):
             i_CEB=0,
             i_I=clk125.p, i_IB=clk125.n,
             o_O=self.clk125_buf,
-            o_ODIV2=self.clk125_div2)
+            o_ODIV2=self.clk125_div2,
+            p_CLKCM_CFG="TRUE",
+            p_CLKRCV_TRST="TRUE",
+            p_CLKSWING_CFG=3)
 
         self.submodules.clk_sw_fsm = ClockSwitchFSM()
 
@@ -231,7 +234,10 @@ class _SysCRG(Module):
             i_CEB=0,
             i_I=clk125.p, i_IB=clk125.n,
             o_O=self.clk125_buf,
-            o_ODIV2=self.clk125_div2)
+            o_ODIV2=self.clk125_div2,
+            p_CLKCM_CFG="TRUE",
+            p_CLKRCV_TRST="TRUE",
+            p_CLKSWING_CFG=3)
 
         mmcm_locked = Signal()
         mmcm_fb = Signal()

--- a/misoc/targets/sayma_rtm.py
+++ b/misoc/targets/sayma_rtm.py
@@ -29,7 +29,10 @@ class CRG(Module):
             self.specials += Instance("IBUFDS_GTE2",
                 i_CEB=0,
                 i_I=clk125.p, i_IB=clk125.n,
-                o_ODIV2=clkin1)
+                o_ODIV2=clkin1,
+                p_CLKCM_CFG="TRUE",
+                p_CLKRCV_TRST="TRUE",
+                p_CLKSWING_CFG=3)
         else:
             raise ValueError
         self.specials += [


### PR DESCRIPTION
Input clock is terminated internally with 50 Ohm on each leg and to 4/5 MGTAVCC.