### PR TITLE
[WIP] Remove clock switch for EEM FMC Carrier

### DIFF
--- a/misoc/targets/efc.py
+++ b/misoc/targets/efc.py
@@ -34,77 +34,15 @@ class AsyncResetSynchronizerBUFG(Module):
         ]
 
 
-class ClockSwitchFSM(Module):
-    def __init__(self):
-        self.i_clk_sw = Signal()
-
-        self.o_clk_sw = Signal()
-        self.o_reset = Signal()
-
-        ###
-
-        i_switch = Signal()
-        o_switch = Signal()
-        reset = Signal()
-
-        # at 125MHz bootstrap cd, will get around 0.5ms
-        delay_counter = Signal(16, reset=0xFFFF)
-
-        # register to prevent glitches
-        self.sync.bootstrap += [
-            self.o_clk_sw.eq(o_switch),
-            self.o_reset.eq(reset),
-        ]
-
-        self.o_clk_sw.attr.add("no_retiming")
-        self.o_reset.attr.add("no_retiming")
-        self.i_clk_sw.attr.add("no_retiming")
-        i_switch.attr.add("no_retiming")
-
-        self.specials += MultiReg(self.i_clk_sw, i_switch, "bootstrap")
-
-        fsm = ClockDomainsRenamer("bootstrap")(FSM(reset_state="START"))
-
-        self.submodules += fsm
-
-        fsm.act("START",
-            If(i_switch & ~o_switch,
-                NextState("RESET_START"))
-        )
-        
-        fsm.act("RESET_START",
-            reset.eq(1),
-            If(delay_counter == 0,
-                NextValue(delay_counter, 0xFFFF),
-                NextState("CLOCK_SWITCH")
-            ).Else(
-                NextValue(delay_counter, delay_counter-1),
-            )
-        )
-
-        fsm.act("CLOCK_SWITCH",
-            reset.eq(1),
-            NextValue(o_switch, 1),
-            NextValue(delay_counter, delay_counter-1),
-            If(delay_counter == 0,
-                NextState("START"))
-        )
-
-
 class _RtioSysCRG(Module, AutoCSR):
     def __init__(self, platform):
         self.clock_domains.cd_sys = ClockDomain()
         self.clock_domains.cd_sys4x = ClockDomain(reset_less=True)
         self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
+        self.clock_domains.cd_eem_sys = ClockDomain()
+        self.clock_domains.cd_eem_sys5x = ClockDomain(reset_less=True)
         self.clock_domains.cd_clk200 = ClockDomain()
 
-        # for FSM only
-        self.clock_domains.cd_bootstrap = ClockDomain(reset_less=True)
-        self.switch_done = CSRStatus()
-
-        self._configured = False
-
-        # bootstrap clock
         clk125 = platform.request("gtp_clk")
         platform.add_period_constraint(clk125, 8.)
         self.clk125_buf = Signal()
@@ -118,7 +56,12 @@ class _RtioSysCRG(Module, AutoCSR):
             p_CLKRCV_TRST="TRUE",
             p_CLKSWING_CFG=3)
 
-        self.submodules.clk_sw_fsm = ClockSwitchFSM()
+        self.switched_clk = CSR()
+        switched_clk_r = Signal(reset_less=True)
+        self.sync += If(self.switched_clk.re, switched_clk_r.eq(1))
+
+        self.had_clk_switch = CSRStatus()
+        self.comb += self.had_clk_switch.status.eq(switched_clk_r)
 
         pll_clk200 = Signal()
         pll_clk125 = Signal()
@@ -138,17 +81,10 @@ class _RtioSysCRG(Module, AutoCSR):
 
                 # 200MHz for IDELAYCTRL
                 p_CLKOUT0_DIVIDE=5, p_CLKOUT0_PHASE=0.0, o_CLKOUT0=pll_clk200,
-                # 125MHz for bootstrap
-                p_CLKOUT1_DIVIDE=8, p_CLKOUT1_PHASE=0.0, o_CLKOUT1=pll_clk125
             ),
-            Instance("BUFG", i_I=pll_clk125, o_O=self.cd_bootstrap.clk),
             Instance("BUFG", i_I=pll_clk200, o_O=self.cd_clk200.clk),
             AsyncResetSynchronizer(self.cd_clk200, ~self.pll_locked),
-            MultiReg(self.clk_sw_fsm.o_clk_sw, self.switch_done.status)
         ]
-
-        platform.add_false_path_constraints(self.cd_sys.clk, 
-            self.clk125_buf, self.cd_bootstrap.clk, pll_clk125)
 
         reset_counter = Signal(4, reset=15)
         ic_reset = Signal(reset=1)
@@ -160,33 +96,25 @@ class _RtioSysCRG(Module, AutoCSR):
             )
         self.specials += Instance("IDELAYCTRL", i_REFCLK=ClockSignal("clk200"), i_RST=ic_reset)
 
-    def configure(self, main_clk, clk_sw=None):
-        # allow configuration of the MMCME2, depending on clock source
-        # if using RtioSysCRG, this function *must* be called
-        self._configured = True
-
-        mmcm_fb_in = Signal()
-        mmcm_fb_out = Signal()
-        mmcm_locked = Signal()
+        mmcm_fb_in = [ Signal() for _ in range(2) ]
+        mmcm_fb_out = [ Signal() for _ in range(2) ]
+        mmcm_locked = [ Signal() for _ in range(2) ]
         mmcm_sys = Signal()
         mmcm_sys4x = Signal()
         mmcm_sys4x_dqs = Signal()
+        mmcm_eem_sys = Signal()
+        mmcm_eem_sys5x = Signal()
         self.specials += [
-            Instance("MMCME2_ADV",
-                p_CLKIN1_PERIOD=8.0,
-                i_CLKIN1=main_clk,
-                p_CLKIN2_PERIOD=8.0,
-                i_CLKIN2=self.cd_bootstrap.clk,
+            Instance("MMCME2_BASE",
+                p_CLKIN1_PERIOD=16.0,
+                i_CLKIN1=self.clk125_div2,
 
-                i_CLKINSEL=self.clk_sw_fsm.o_clk_sw,
-                i_RST=self.clk_sw_fsm.o_reset,
+                i_CLKFBIN=mmcm_fb_in[0],
+                o_CLKFBOUT=mmcm_fb_out[0],
+                o_LOCKED=mmcm_locked[0],
 
-                i_CLKFBIN=mmcm_fb_in,
-                o_CLKFBOUT=mmcm_fb_out,
-                o_LOCKED=mmcm_locked,
-
-                # VCO @ 1GHz with MULT=8
-                p_CLKFBOUT_MULT_F=8, p_DIVCLK_DIVIDE=1,
+                # VCO @ 1GHz with MULT=16
+                p_CLKFBOUT_MULT_F=16, p_DIVCLK_DIVIDE=1,
 
                 # 125MHz
                 p_CLKOUT0_DIVIDE_F=8, p_CLKOUT0_PHASE=0.0, o_CLKOUT0=mmcm_sys,
@@ -195,123 +123,47 @@ class _RtioSysCRG(Module, AutoCSR):
                 p_CLKOUT1_DIVIDE=2, p_CLKOUT1_PHASE=0.0, o_CLKOUT1=mmcm_sys4x,
                 p_CLKOUT2_DIVIDE=2, p_CLKOUT2_PHASE=90.0, o_CLKOUT2=mmcm_sys4x_dqs,
             ),
-            Instance("BUFG", i_I=mmcm_sys, o_O=self.cd_sys.clk),
-            Instance("BUFG", i_I=mmcm_sys4x, o_O=self.cd_sys4x.clk),
-            Instance("BUFG", i_I=mmcm_sys4x_dqs, o_O=self.cd_sys4x_dqs.clk),
-            Instance("BUFG", i_I=mmcm_fb_out, o_O=mmcm_fb_in),
-        ]
-        # reset if MMCM or PLL loses lock or when switching
-        self.submodules += AsyncResetSynchronizerBUFG(self.cd_sys, 
-            ~self.pll_locked | ~mmcm_locked | self.clk_sw_fsm.o_reset)
-
-        # allow triggering the clock switch through either CSR,
-        # or a different event, e.g. tx_init.done
-        if clk_sw is not None:
-            self.comb += self.clk_sw_fsm.i_clk_sw.eq(clk_sw)
-        else:
-            self.clock_sel = CSRStorage()
-            self.comb += self.clk_sw_fsm.i_clk_sw.eq(self.clock_sel.storage)
-
-    def do_finalize(self):
-        if not self._configured:
-            raise FinalizeError("RtioSysCRG must be configured")
-        
-
-class _SysCRG(Module):
-    def __init__(self, platform):
-        self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_sys4x = ClockDomain(reset_less=True)
-        self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
-        self.clock_domains.cd_clk200 = ClockDomain()
-
-        clk125 = platform.request("gtp_clk")
-        platform.add_period_constraint(clk125, 8.)
-        self.clk125_buf = Signal()
-        self.clk125_div2 = Signal()
-        self.specials += Instance("IBUFDS_GTE2",
-            i_CEB=0,
-            i_I=clk125.p, i_IB=clk125.n,
-            o_O=self.clk125_buf,
-            o_ODIV2=self.clk125_div2,
-            p_CLKCM_CFG="TRUE",
-            p_CLKRCV_TRST="TRUE",
-            p_CLKSWING_CFG=3)
-
-        mmcm_locked = Signal()
-        mmcm_fb = Signal()
-        mmcm_sys = Signal()
-        mmcm_sys4x = Signal()
-        mmcm_sys4x_dqs = Signal()
-        pll_locked = Signal()
-        pll_fb = Signal()
-        pll_clk200 = Signal()
-        self.specials += [
             Instance("MMCME2_BASE",
                 p_CLKIN1_PERIOD=16.0,
                 i_CLKIN1=self.clk125_div2,
 
-                i_CLKFBIN=mmcm_fb,
-                o_CLKFBOUT=mmcm_fb,
-                o_LOCKED=mmcm_locked,
+                i_CLKFBIN=mmcm_fb_in[1],
+                o_CLKFBOUT=mmcm_fb_out[1],
+                o_LOCKED=mmcm_locked[1],
 
-                # VCO @ 1GHz with MULT=16
-                p_CLKFBOUT_MULT_F=14.5, p_DIVCLK_DIVIDE=1,
+                # VCO @ 1.25 GHz with MULT=20
+                p_CLKFBOUT_MULT_F=20, p_DIVCLK_DIVIDE=1,
 
-                # ~125MHz
-                p_CLKOUT0_DIVIDE_F=8.0, p_CLKOUT0_PHASE=0.0, o_CLKOUT0=mmcm_sys,
+                # 125MHz
+                p_CLKOUT0_DIVIDE_F=10, p_CLKOUT0_PHASE=0.0, o_CLKOUT0=mmcm_eem_sys,
 
-                # ~500MHz. Must be more than 400MHz as per DDR3 specs.
-                p_CLKOUT1_DIVIDE=2, p_CLKOUT1_PHASE=0.0, o_CLKOUT1=mmcm_sys4x,
-                p_CLKOUT2_DIVIDE=2, p_CLKOUT2_PHASE=90.0, o_CLKOUT2=mmcm_sys4x_dqs,
-            ),
-            Instance("PLLE2_BASE",
-                p_CLKIN1_PERIOD=16.0,
-                i_CLKIN1=self.clk125_div2,
-
-                i_CLKFBIN=pll_fb,
-                o_CLKFBOUT=pll_fb,
-                o_LOCKED=pll_locked,
-
-                # VCO @ 1GHz
-                p_CLKFBOUT_MULT=16, p_DIVCLK_DIVIDE=1,
-
-                # 200MHz for IDELAYCTRL
-                p_CLKOUT0_DIVIDE=5, p_CLKOUT0_PHASE=0.0, o_CLKOUT0=pll_clk200,
+                # 625MHz
+                p_CLKOUT1_DIVIDE=2, p_CLKOUT1_PHASE=0.0, o_CLKOUT1=mmcm_eem_sys5x,
             ),
             Instance("BUFG", i_I=mmcm_sys, o_O=self.cd_sys.clk),
             Instance("BUFG", i_I=mmcm_sys4x, o_O=self.cd_sys4x.clk),
             Instance("BUFG", i_I=mmcm_sys4x_dqs, o_O=self.cd_sys4x_dqs.clk),
-            Instance("BUFG", i_I=pll_clk200, o_O=self.cd_clk200.clk),
-            AsyncResetSynchronizer(self.cd_clk200, ~pll_locked),
+            Instance("BUFG", i_I=mmcm_eem_sys, o_O=self.cd_eem_sys.clk),
+            Instance("BUFG", i_I=mmcm_eem_sys5x, o_O=self.cd_eem_sys5x.clk),
+            Instance("BUFG", i_I=mmcm_fb_out[0], o_O=mmcm_fb_in[0]),
+            Instance("BUFG", i_I=mmcm_fb_out[1], o_O=mmcm_fb_in[1]),
         ]
-        self.submodules += AsyncResetSynchronizerBUFG(self.cd_sys, ~mmcm_locked),
 
-        reset_counter = Signal(4, reset=15)
-        ic_reset = Signal(reset=1)
-        self.sync.clk200 += \
-            If(reset_counter != 0,
-                reset_counter.eq(reset_counter - 1)
-            ).Else(
-                ic_reset.eq(0)
-            )
-        self.specials += Instance("IDELAYCTRL", i_REFCLK=ClockSignal("clk200"), i_RST=ic_reset)
+        self.submodules += AsyncResetSynchronizerBUFG(self.cd_sys, ~mmcm_locked[0])
+        self.submodules += AsyncResetSynchronizerBUFG(self.cd_eem_sys, ~mmcm_locked[1])
 
 
 class BaseSoC(SoCSDRAM):
-    def __init__(self, sdram_controller_type="minicon", rtio_sys_merge=False, 
-                 clk_freq=None, **kwargs):
+    def __init__(self, sdram_controller_type="minicon", clk_freq=None, **kwargs):
         platform = efc.Platform()
 
         if not clk_freq:
-            clk_freq = 125e6 if rtio_sys_merge else 125e6*14.5/16
+            clk_freq = 125e6
 
         SoCSDRAM.__init__(self, platform, cpu_reset_address=0x400000, clk_freq=clk_freq, **kwargs)
 
-        if rtio_sys_merge:
-            self.submodules.crg = _RtioSysCRG(platform)
-            self.csr_devices.append("crg")
-        else:
-            self.submodules.crg = _SysCRG(platform)
+        self.submodules.crg = _RtioSysCRG(platform)
+        self.csr_devices.append("crg")
 
         self.platform.add_period_constraint(self.crg.cd_sys.clk, 1e9/self.clk_freq)
 

--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -98,6 +98,8 @@ class _RtioSysCRG(Module, AutoCSR):
         self.clock_domains.cd_sys = ClockDomain()
         self.clock_domains.cd_sys4x = ClockDomain(reset_less=True)
         self.clock_domains.cd_sys4x_dqs = ClockDomain(reset_less=True)
+        self.clock_domains.cd_eem_sys = ClockDomain()
+        self.clock_domains.cd_eem_sys5x = ClockDomain(reset_less=True)
         self.clock_domains.cd_clk200 = ClockDomain()
 
         # for FSM only
@@ -150,7 +152,7 @@ class _RtioSysCRG(Module, AutoCSR):
         ]
 
         platform.add_false_path_constraints(self.cd_sys.clk, 
-            self.clk125_buf, self.cd_bootstrap.clk, pll_clk125)
+            self.clk125_buf, self.cd_bootstrap.clk, pll_clk125, self.cd_eem_sys.clk)
 
         reset_counter = Signal(4, reset=15)
         ic_reset = Signal(reset=1)
@@ -167,12 +169,14 @@ class _RtioSysCRG(Module, AutoCSR):
         # if using RtioSysCRG, this function *must* be called
         self._configured = True
 
-        mmcm_fb_in = Signal()
-        mmcm_fb_out = Signal()
-        mmcm_locked = Signal()
+        mmcm_fb_in = [ Signal() for _ in range(2) ]
+        mmcm_fb_out = [ Signal() for _ in range(2) ]
+        mmcm_locked = [ Signal() for _ in range(2) ]
         mmcm_sys = Signal()
         mmcm_sys4x = Signal()
         mmcm_sys4x_dqs = Signal()
+        mmcm_eem_sys = Signal()
+        mmcm_eem_sys5x = Signal()
         self.specials += [
             Instance("MMCME2_ADV",
                 p_CLKIN1_PERIOD=8.0,
@@ -183,9 +187,9 @@ class _RtioSysCRG(Module, AutoCSR):
                 i_CLKINSEL=self.clk_sw_fsm.o_clk_sw,
                 i_RST=self.clk_sw_fsm.o_reset,
 
-                i_CLKFBIN=mmcm_fb_in,
-                o_CLKFBOUT=mmcm_fb_out,
-                o_LOCKED=mmcm_locked,
+                i_CLKFBIN=mmcm_fb_in[0],
+                o_CLKFBOUT=mmcm_fb_out[0],
+                o_LOCKED=mmcm_locked[0],
 
                 # VCO @ 1GHz with MULT=8
                 p_CLKFBOUT_MULT_F=8, p_DIVCLK_DIVIDE=1,
@@ -197,14 +201,38 @@ class _RtioSysCRG(Module, AutoCSR):
                 p_CLKOUT1_DIVIDE=2, p_CLKOUT1_PHASE=0.0, o_CLKOUT1=mmcm_sys4x,
                 p_CLKOUT2_DIVIDE=2, p_CLKOUT2_PHASE=90.0, o_CLKOUT2=mmcm_sys4x_dqs,
             ),
+            Instance("MMCME2_BASE",
+                p_CLKIN1_PERIOD=8.0,
+                i_CLKIN1=main_clk,
+
+                i_RST=self.clk_sw_fsm.o_reset,
+
+                i_CLKFBIN=mmcm_fb_in[1],
+                o_CLKFBOUT=mmcm_fb_out[1],
+                o_LOCKED=mmcm_locked[1],
+
+                # VCO @ 1.25 GHz with MULT=10
+                p_CLKFBOUT_MULT_F=10, p_DIVCLK_DIVIDE=1,
+
+                # 125MHz
+                p_CLKOUT0_DIVIDE_F=10, p_CLKOUT0_PHASE=0.0, o_CLKOUT0=mmcm_eem_sys,
+
+                # 625MHz
+                p_CLKOUT1_DIVIDE=2, p_CLKOUT1_PHASE=0.0, o_CLKOUT1=mmcm_eem_sys5x,
+            ),
             Instance("BUFG", i_I=mmcm_sys, o_O=self.cd_sys.clk),
             Instance("BUFG", i_I=mmcm_sys4x, o_O=self.cd_sys4x.clk),
             Instance("BUFG", i_I=mmcm_sys4x_dqs, o_O=self.cd_sys4x_dqs.clk),
-            Instance("BUFG", i_I=mmcm_fb_out, o_O=mmcm_fb_in),
+            Instance("BUFG", i_I=mmcm_eem_sys, o_O=self.cd_eem_sys.clk),
+            Instance("BUFG", i_I=mmcm_eem_sys5x, o_O=self.cd_eem_sys5x.clk),
+            Instance("BUFG", i_I=mmcm_fb_out[0], o_O=mmcm_fb_in[0]),
+            Instance("BUFG", i_I=mmcm_fb_out[1], o_O=mmcm_fb_in[1]),
         ]
         # reset if MMCM or PLL loses lock or when switching
         self.submodules += AsyncResetSynchronizerBUFG(self.cd_sys, 
-            ~self.pll_locked | ~mmcm_locked | self.clk_sw_fsm.o_reset)
+            ~self.pll_locked | ~mmcm_locked[0] | self.clk_sw_fsm.o_reset)
+        self.submodules += AsyncResetSynchronizerBUFG(self.cd_eem_sys, 
+            ~self.pll_locked | ~mmcm_locked[1] | self.clk_sw_fsm.o_reset)
 
         # allow triggering the clock switch through either CSR,
         # or a different event, e.g. tx_init.done


### PR DESCRIPTION
## Description
The clock switch logic was introduced in #134 as a direct clone of the Kasli target. But there are only 1 clock source in EFC.
This PR mainly aims to remove the clock switch logic for EFC and unify the 2 CRGs.

### TODO
Move the new clock domains for drtio-over-eem to some other PR.