### PR TITLE
efc: add support for custom platform name

### DIFF
--- a/misoc/targets/efc.py
+++ b/misoc/targets/efc.py
@@ -151,8 +151,8 @@ class _RtioSysCRG(Module, AutoCSR):
 
 
 class BaseSoC(SoCSDRAM):
-    def __init__(self, sdram_controller_type="minicon", clk_freq=None, **kwargs):
-        platform = efc.Platform()
+    def __init__(self, sdram_controller_type="minicon", clk_freq=None, platform_name=None, **kwargs):
+        platform = efc.Platform(name=platform_name)
 
         if not clk_freq:
             clk_freq = 125e6


### PR DESCRIPTION
This PR allows custom name to be assigned to efc platform from artiq repo.

This will affect the configuration flag "soc_platform" in artiq rust firmware.
(By default, `#[cfg(soc_platform = "efc")]` )

Related PR:
PR in [artiq](https://github.com/m-labs/artiq/pull/2223)
PR in [migen](https://github.com/m-labs/migen/pull/278)