### PR TITLE
Kc705: mmcm_locked -> self.mmcm.locked in RtioSysCRG and add optional ext_async_rst to AsyncResetSynchronizerBUFG

### DIFF
--- a/misoc/targets/kc705.py
+++ b/misoc/targets/kc705.py
@@ -145,7 +145,7 @@ class _RtioSysCRG(Module, AutoCSR):
         mmcm_fb_in = Signal()
         mmcm_fb_out = Signal()
         mmcm_fb = Signal()
-        mmcm_locked = Signal()
+        self.mmcm_locked = Signal()
 
         mmcm_sys = Signal()
         mmcm_sys4x = Signal()
@@ -161,7 +161,7 @@ class _RtioSysCRG(Module, AutoCSR):
 
                 i_CLKFBIN=mmcm_fb_in,
                 o_CLKFBOUT=mmcm_fb_out,
-                o_LOCKED=mmcm_locked,
+                o_LOCKED=self.mmcm_locked,
 
                 # VCO @ 1GHz with MULT=8
                 p_CLKFBOUT_MULT_F=8, p_DIVCLK_DIVIDE=1,
@@ -174,7 +174,7 @@ class _RtioSysCRG(Module, AutoCSR):
             Instance("BUFG", i_I=mmcm_sys, o_O=self.cd_sys.clk),
             Instance("BUFG", i_I=mmcm_sys4x, o_O=self.cd_sys4x.clk),
             Instance("BUFG", i_I=mmcm_fb_out, o_O=mmcm_fb_in),
-            AsyncResetSynchronizer(self.cd_sys, ~mmcm_locked)
+            AsyncResetSynchronizer(self.cd_sys, ~self.mmcm_locked)
         ]
 
         self.platform.add_false_path_constraints(self.cd_sys.clk, main_clk)

--- a/misoc/targets/kc705.py
+++ b/misoc/targets/kc705.py
@@ -137,7 +137,7 @@ class _RtioSysCRG(Module, AutoCSR):
             )
         self.specials += Instance("IDELAYCTRL", i_REFCLK=ClockSignal("clk200"), i_RST=ic_reset)
 
-    def configure(self, main_clk, clk_sw=None):
+    def configure(self, main_clk, clk_sw=None, ext_async_rst=None):
         # allow configuration of the MMCME2, depending on clock source
         # if using RtioSysCRG, this function *must* be called
         self._configured = True
@@ -174,8 +174,12 @@ class _RtioSysCRG(Module, AutoCSR):
             Instance("BUFG", i_I=mmcm_sys, o_O=self.cd_sys.clk),
             Instance("BUFG", i_I=mmcm_sys4x, o_O=self.cd_sys4x.clk),
             Instance("BUFG", i_I=mmcm_fb_out, o_O=mmcm_fb_in),
-            AsyncResetSynchronizer(self.cd_sys, ~self.mmcm_locked)
         ]
+
+        if ext_async_rst is not None:
+            self.specials += AsyncResetSynchronizer(self.cd_sys, ~self.mmcm_locked | ext_async_rst)
+        else:
+            self.specials += AsyncResetSynchronizer(self.cd_sys, ~self.mmcm_locked)
 
         self.platform.add_false_path_constraints(self.cd_sys.clk, main_clk)
 


### PR DESCRIPTION
# Description
PR #144 is ported to kc705 platform. 

# Related PR:
Artiq: (To be added)
