### PR TITLE
Remove xbuild, update llvm_asm macro to asm

### DIFF
--- a/misoc/integration/sdram_init.py
+++ b/misoc/integration/sdram_init.py
@@ -266,7 +266,7 @@ pub mod sdram_phy {
         while cycles > 0 {
             unsafe {
                 #[cfg(not(target_arch = "or1k"))]
-                llvm_asm!(""::::"volatile");
+                asm!("");
 
                 #[cfg(target_arch = "or1k")]
                 asm!(""::::"volatile")

--- a/misoc/software/common.mak
+++ b/misoc/software/common.mak
@@ -37,10 +37,10 @@ ifeq ($(CPU),or1k)
 CARGO_normal   := env CARGO_TARGET_DIR=$(realpath .)/cargo TARGET_AR=$(AR_normal) cargo rustc --target $(CARGO_TRIPLE)
 endif
 ifeq ($(CPU),vexriscv)
-CARGO_normal   := env TARGET_AR=$(AR_normal) cargo xbuild
+CARGO_normal   := env TARGET_AR=$(AR_normal) cargo build -Z build-std=core,compiler_builtins,alloc
 endif
 ifeq ($(CPU),vexriscv-g)
-CARGO_normal   := env TARGET_AR=$(AR_normal) cargo xbuild
+CARGO_normal   := env TARGET_AR=$(AR_normal) cargo build -Z build-std=core,compiler_builtins,alloc
 endif
 
 CC_quiet      = @echo " CC      " $@ && $(CC_normal)


### PR DESCRIPTION
As a part of artiq#2401, to update the toolchain, two things had to be done:
- xbuild is deprecated (by the author himself), replaced with ``cargo build -Z build-std=...``,
- ``llvm_asm!`` macro is deprecated and replaced by ``asm!`` (but with different syntax than previous ``asm!``). This is not an error (yet, on 2021-09-01 Rust nightly), but produces build warnings, so better to take care of this now.