### PR TITLE
Implement Wishbone Burst Support for Memory Controller

### DIFF
--- a/misoc/interconnect/wishbone.py
+++ b/misoc/interconnect/wishbone.py
@@ -90,7 +90,7 @@ class Arbiter(Module):
                         self.comb += dest.eq(source)
 
         # connect bus requests to round-robin selector
-        reqs = [m.cyc & ~m.ack for m in masters]
+        reqs = [m.cyc & ~(m.ack & (m.cti != 0b010)) for m in masters]
         self.comb += self.rr.request.eq(Cat(*reqs))
 
 


### PR DESCRIPTION
## Description
Burst access is handled as the following:
- Memory controller waits for DFI to confirm read success before ack back.
- Write bursts are always ack'd immediately, once a DFI instruction is issued.
- Address are pre-emptively incremented after issuing each DFI instruction, without inputs from the bus master.
- Burst will not cross page boundary. The controller always return the state back to IDLE.
- Memory controller issues refresh instruction if a burst **may** cause an un-timely refresh.

To support burst access, the wishbone arbiter shall not release `grant` to masters during a burst.