### PR TITLE
Fix L2 Cache Size for 64-bits Data-bus-width CPUs

### DIFF
--- a/misoc/integration/soc_sdram.py
+++ b/misoc/integration/soc_sdram.py
@@ -79,7 +79,7 @@ class SoCSDRAM(SoCCore):
 
             bridge_if = self.get_native_sdram_if()
             if self.l2_size:
-                l2_cache = wishbone.Cache(self.l2_size//4,
+                l2_cache = wishbone.Cache(self.l2_size//(self.cpu_dw//8),
                     self._cpulevel_sdram_if_arbitrated, bridge_if)
                 # XXX Vivado ->2015.1 workaround, Vivado is not able to map correctly our L2 cache.
                 # Issue is reported to Xilinx and should be fixed in next releases (> 2017.2).

--- a/misoc/interconnect/wishbone.py
+++ b/misoc/interconnect/wishbone.py
@@ -461,7 +461,7 @@ class Cache(Module):
     """Cache
 
     This module is a write-back wishbone cache that can be used as a L2 cache.
-    Cachesize (in 32-bit words) is the size of the data store and must be a power of 2
+    Cachesize (in CPU data-width-bytes) is the size of the data store and must be a power of 2
     """
     def __init__(self, cachesize, master, slave):
         self.master = master


### PR DESCRIPTION
## Description
#124 supports 64-bits CPU data bus, The PR adjusts the wishbone L2 cache according to the bus width.

64-bits CPU doubles the L2 cache size before this patch, without also adjusting the config, leading to L2 cache unable to be flushed under some memory access pattern.