### PR TITLE
Wishbone: Disallow artiber to switch interface access while bursting

### DIFF
--- a/misoc/interconnect/wishbone.py
+++ b/misoc/interconnect/wishbone.py
@@ -90,7 +90,7 @@ class Arbiter(Module):
                         self.comb += dest.eq(source)
 
         # connect bus requests to round-robin selector
-        reqs = [m.cyc & ~m.ack for m in masters]
+        reqs = [m.cyc & ~(m.ack & (m.cti != 0b010)) for m in masters]
         self.comb += self.rr.request.eq(Cat(*reqs))
 
 


### PR DESCRIPTION
Required before merging any PR that involves wishbone burst.