### PR TITLE
Workaround hold violation by reimplement clock divider in ICAP

### DIFF
--- a/misoc/cores/icap.py
+++ b/misoc/cores/icap.py
@@ -4,7 +4,7 @@ from migen.genlib.cdc import PulseSynchronizer
 from misoc.interconnect.csr import AutoCSR, CSR
 
 class ICAP(Module, AutoCSR):
-    def __init__(self, fpga_family, clk_divide_ratio="2"):
+    def __init__(self, fpga_family, clk_divide_ratio=2):
         """
         ICAP module.
 
@@ -17,7 +17,7 @@ class ICAP(Module, AutoCSR):
             FPGA family name, used to determine the version of primitive. 
             Supported family: ultrascale (metlino), 7series (kasli/kc705)
 
-        clk_divide_ratio : str
+        clk_divide_ratio : int
             Optional. The divide ratio of the clock frequency from system clock.
         """
         self.iprog = CSR()
@@ -48,13 +48,13 @@ class ICAP(Module, AutoCSR):
         self.clock_domains.cd_icap = ClockDomain(reset_less=True)
 
         if fpga_family == "7series":
-            counter = Signal(max=int(clk_divide_ratio), reset_less=True)
+            counter = Signal(max=clk_divide_ratio, reset_less=True)
             counter_rst = Signal()
 
             self.comb += counter_rst.eq(counter == 0)
             self.sync += \
                 If(counter_rst,
-                    counter.eq(int(clk_divide_ratio)-1)
+                    counter.eq(clk_divide_ratio-1)
                 ).Else(
                     counter.eq(counter - 1)
                 )
@@ -67,7 +67,7 @@ class ICAP(Module, AutoCSR):
         elif fpga_family == "ultrascale":
             # BUFGCE_DIV primitive module
             self.specials += Instance("BUFGCE_DIV",
-                p_BUFGCE_DIVIDE = int(clk_divide_ratio),
+                p_BUFGCE_DIVIDE = clk_divide_ratio,
 
                 o_O = self.cd_icap.clk,
                 i_CE = 1,

--- a/misoc/cores/icap.py
+++ b/misoc/cores/icap.py
@@ -75,7 +75,7 @@ class ICAP(Module, AutoCSR):
                     bufhce=self.bufhce
                 )
             else:
-                ValueError("7series platform instance missing, cannot constrain clock")
+                raise ValueError("7series platform instance missing, cannot constrain clock")
         elif fpga_family == "ultrascale":
             # BUFGCE_DIV primitive module
             self.specials += Instance("BUFGCE_DIV",

--- a/misoc/cores/icap.py
+++ b/misoc/cores/icap.py
@@ -57,12 +57,12 @@ class ICAP(Module, AutoCSR):
             self.comb += counter_rst.eq(counter == 0)
             self.sync += \
                 If(counter_rst,
-                    counter.eq(clk_divide_ratio-1)
+                    counter.eq(clk_divide_ratio - 1)
                 ).Else(
                     counter.eq(counter - 1)
                 )
             
-            # sys_clk gating. Only 1 in clk_divide_ratio-1 cycles pass through
+            # sys_clk gating. Only 1 in clk_divide_ratio cycles pass through
             self.specials.bufhce = Instance("BUFHCE",
                 o_O = self.cd_icap.clk,
                 i_CE = counter_rst,
@@ -71,7 +71,7 @@ class ICAP(Module, AutoCSR):
             if platform is not None:
                 platform.add_platform_command(
                     "create_generated_clock -name icap_clk -source [get_pins {bufhce}/I] "
-                    "-edges {{1 2 " + str(2*clk_divide_ratio+1) + "}} [get_pins {bufhce}/O]",
+                    "-edges {{1 2 " + str(2 * clk_divide_ratio + 1) + "}} [get_pins {bufhce}/O]",
                     bufhce=self.bufhce
                 )
             else:

--- a/misoc/targets/efc.py
+++ b/misoc/targets/efc.py
@@ -215,12 +215,8 @@ class BaseSoC(SoCSDRAM):
             self.register_rom(self.spiflash.bus, 16*1024*1024)
             self.csr_devices.append("spiflash")
         
-        self.submodules.icap = icap.ICAP("7series")
+        self.submodules.icap = icap.ICAP("7series", platform=platform)
         self.csr_devices.append("icap")
-        platform.add_platform_command(
-            "create_generated_clock -name icap_clk -source [get_pins {bufhce}/I] -edges {{1 2 5}} [get_pins {bufhce}/O]",
-            bufhce=self.icap.bufhce
-        )
 
 
 def main():

--- a/misoc/targets/efc.py
+++ b/misoc/targets/efc.py
@@ -217,6 +217,10 @@ class BaseSoC(SoCSDRAM):
         
         self.submodules.icap = icap.ICAP("7series")
         self.csr_devices.append("icap")
+        platform.add_platform_command(
+            "create_generated_clock -name icap_clk -source [get_pins {bufhce}/I] -edges {{1 2 5}} [get_pins {bufhce}/O]",
+            bufhce=self.icap.bufhce
+        )
 
 
 def main():

--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -437,6 +437,10 @@ class BaseSoC(SoCSDRAM):
         
         self.submodules.icap = icap.ICAP("7series")
         self.csr_devices.append("icap")
+        platform.add_platform_command(
+            "create_generated_clock -name icap_clk -source [get_pins {bufhce}/I] -edges {{1 2 5}} [get_pins {bufhce}/O]",
+            bufhce=self.icap.bufhce
+        )
 
 
 class MiniSoC(BaseSoC):

--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -435,12 +435,8 @@ class BaseSoC(SoCSDRAM):
             self.register_rom(self.spiflash.bus, 16*1024*1024)
             self.csr_devices.append("spiflash")
         
-        self.submodules.icap = icap.ICAP("7series")
+        self.submodules.icap = icap.ICAP("7series", platform=platform)
         self.csr_devices.append("icap")
-        platform.add_platform_command(
-            "create_generated_clock -name icap_clk -source [get_pins {bufhce}/I] -edges {{1 2 5}} [get_pins {bufhce}/O]",
-            bufhce=self.icap.bufhce
-        )
 
 
 class MiniSoC(BaseSoC):

--- a/misoc/targets/kc705.py
+++ b/misoc/targets/kc705.py
@@ -302,6 +302,10 @@ class BaseSoC(SoCSDRAM):
             self.csr_devices.append("spiflash")
         self.submodules.icap = icap.ICAP("7series")
         self.csr_devices.append("icap")
+        platform.add_platform_command(
+            "create_generated_clock -name icap_clk -source [get_pins {bufhce}/I] -edges {{1 2 5}} [get_pins {bufhce}/O]",
+            bufhce=self.icap.bufhce
+        )
 
 
 class MiniSoC(BaseSoC):

--- a/misoc/targets/kc705.py
+++ b/misoc/targets/kc705.py
@@ -300,12 +300,8 @@ class BaseSoC(SoCSDRAM):
             self.flash_boot_address = 0xb40000
             self.register_rom(self.spiflash.bus, 16*1024*1024)
             self.csr_devices.append("spiflash")
-        self.submodules.icap = icap.ICAP("7series")
+        self.submodules.icap = icap.ICAP("7series", platform=platform)
         self.csr_devices.append("icap")
-        platform.add_platform_command(
-            "create_generated_clock -name icap_clk -source [get_pins {bufhce}/I] -edges {{1 2 5}} [get_pins {bufhce}/O]",
-            bufhce=self.icap.bufhce
-        )
 
 
 class MiniSoC(BaseSoC):


### PR DESCRIPTION
Following the findings in [ARTIQ issue 2630](https://github.com/m-labs/artiq/issues/2630), where inserting a BUFR clocked by the `sys_clk` may correlate to hold time violations. This PR workaround this by replacing the BUFR divider with a BUFH divider, where `sys_clk` is gated and generate a lower frequency `icap_clk`.

The BUFHCE structure follows [AMD vivado forum](https://adaptivesupport.amd.com/s/question/0D52E00006hpe4DSAQ/how-to-divide-a-clock-by-2-with-a-simple-primitive-without-clock-wizard-artix7?language=en_US).

Note the constraints: The duty cycle is the 50% / clock division ratio. Other constraints suggested the post that doesn't use `-edges` will result in vivado reporting 50% duty cycle in the final clock summary report (even if `-duty_cycle` is appropriately applied).

###Tests
Gateware are built and passed timing (for ARTIQ, unless specified).
Built and passed timing: Metlino (MiSoC), Kasli v1 (MiSoC), KC705 all variants.
Able to reboot in ARTIQ: Kasli v2, EFC.