### PR TITLE
L2 cache: Reduce grain fine-ness in Vivado synthesis

### DIFF
--- a/misoc/interconnect/wishbone.py
+++ b/misoc/interconnect/wishbone.py
@@ -500,7 +500,7 @@ class Cache(Module):
         # Data memory
         data_mem = Memory(lw, 2**linebits)
         data_port = data_mem.get_port(write_capable=True, we_granularity=8)
-        self.specials += data_mem, data_port
+        self.specials.data_mem, self.specials.data_port = data_mem, data_port
 
         write_from_slave = Signal()
         adr_inc = Signal()


### PR DESCRIPTION
## Changes
Divide the cache data memory into widths of 64-bits instead of 8 bits (currently via FullMemoryWE).

## Impacts
- vivado seems to infer block RAM more readily when the memory is larger.
- larger cache line sizes can be supported. 128KB cache (like in ARTIQ) may support cache line of size 256 bytes before block RAM utilization rate drops.

## Related issue
https://github.com/m-labs/artiq/pull/2647#issuecomment-2586134640 and the main issue.

Tested on vivado 2024.2.