### PR TITLE
Remove L2 cache synthesis workaround for vivado

### DIFF
--- a/misoc/integration/soc_sdram.py
+++ b/misoc/integration/soc_sdram.py
@@ -83,17 +83,8 @@ class SoCSDRAM(SoCCore):
                 if self.l2_line_size is None: 
                     self.l2_line_size = len(bridge_if.dat_w)//8
 
-                l2_cache = wishbone.Cache(self.l2_size//(self.cpu_dw//8),
+                self.submodules.l2_cache = wishbone.Cache(self.l2_size//(self.cpu_dw//8),
                     self._cpulevel_sdram_if_arbitrated, bridge_if, linesize=self.l2_line_size//(len(bridge_if.dat_w)//8))
-                # XXX Vivado ->2015.1 workaround, Vivado is not able to map correctly our L2 cache.
-                # Issue is reported to Xilinx and should be fixed in next releases (> 2017.2).
-                # Remove this workaround when fixed by Xilinx.
-                from migen.build.xilinx.vivado import XilinxVivadoToolchain
-                if isinstance(self.platform.toolchain, XilinxVivadoToolchain):
-                    from migen.fhdl.simplify import FullMemoryWE
-                    self.submodules.l2_cache = FullMemoryWE()(l2_cache)
-                else:
-                    self.submodules.l2_cache = l2_cache
             else:
                 self.submodules.converter = wishbone.Converter(
                     self._cpulevel_sdram_if_arbitrated, bridge_if)


### PR DESCRIPTION
`FullMemoryWE` is not needed anymore after https://github.com/m-labs/migen/pull/300.
vivado is now able to infer block RAM for the L2 cache. With KC705 MiSoC build:
```
+--------------------------------------+----------------------------------------+------------------------+---+---+------------------------+---+---+------------------+--------+--------+
|Module Name                           | RTL Object                             | PORT A (Depth x Width) | W | R | PORT B (Depth x Width) | W | R | Ports driving FF | RAMB18 | RAMB36 | 
+--------------------------------------+----------------------------------------+------------------------+---+---+------------------------+---+---+------------------+--------+--------+
...
|top                                   | data_mem_reg                           | 128 x 512(WRITE_FIRST) | W | R |                        |   |   | Port A           | 0      | 8      | 
```
With Kasli 2.0 64-bytes cache line ARTIQ build:
```
+-----------------------------------------+----------------------------------------+------------------------+---+---+------------------------+---+---+------------------+--------+--------+
|Module Name                              | RTL Object                             | PORT A (Depth x Width) | W | R | PORT B (Depth x Width) | W | R | Ports driving FF | RAMB18 | RAMB36 | 
+-----------------------------------------+----------------------------------------+------------------------+---+---+------------------------+---+---+------------------+--------+--------+
|top__GCB7                                | data_mem_reg                           | 2 K x 512(WRITE_FIRST) | W | R |                        |   |   | Port A           | 0      | 32     | 
```