### PR TITLE
kasli: Remove clk125_buf false path constraint with bootstrap and sys

### DIFF
--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -169,8 +169,8 @@ class _RtioSysCRG(Module, AutoCSR):
             MultiReg(self.clk_sw_fsm.o_clk_sw, self.switch_done.status)
         ]
 
-        platform.add_false_path_constraints(self.cd_sys.clk, 
-            self.clk125_buf, self.cd_bootstrap.clk, pll_clk_bootstrap)
+        platform.add_false_path_constraints(
+            self.cd_sys.clk, self.cd_bootstrap.clk, pll_clk_bootstrap)
 
         reset_counter = Signal(4, reset=15)
         ic_reset = Signal(reset=1)


### PR DESCRIPTION
Similar context to https://github.com/m-labs/artiq/pull/2677, these critical warning can pop up when building satellite variants.

```
WARNING: [Vivado 12-507] No nets matched 'genericsatellite_genericsatellite_crg_clk125_buf'. [top.xdc:321]
CRITICAL WARNING: [Vivado 12-4739] get_clocks:No valid object(s) found for '--of_objects [get_nets genericsatellite_genericsatellite_crg_clk125_buf]'. [top.xdc:321]
Resolution: Check if the specified object(s) exists in the current design. If it does, ensure that the correct design hierarchy was specified for the object. If you are working with clocks, make sure create_clock was used to create the clock object before it is referenced.
WARNING: [Vivado 12-3521] Clock specified in more than one group: genericsatellite_genericsatellite_crg_pll_clk_bootstrap, genericsatellite_mmcm_fb_out_1, genericsatellite_mmcm_sys4x_1, genericsatellite_mmcm_sys4x_dqs_1, and genericsatellite_mmcm_sys_1 [top.xdc:337]
WARNING: [Vivado 12-507] No nets matched 'genericsatellite_genericsatellite_crg_clk125_buf'. [top.xdc:339]
CRITICAL WARNING: [Vivado 12-4739] get_clocks:No valid object(s) found for '--of_objects [get_nets genericsatellite_genericsatellite_crg_clk125_buf]'. [top.xdc:339]
Resolution: Check if the specified object(s) exists in the current design. If it does, ensure that the correct design hierarchy was specified for the object. If you are working with clocks, make sure create_clock was used to create the clock object before it is referenced.
WARNING: [Vivado 12-507] No nets matched 'genericsatellite_genericsatellite_crg_clk125_buf'. [top.xdc:341]
CRITICAL WARNING: [Vivado 12-4739] get_clocks:No valid object(s) found for '--of_objects [get_nets genericsatellite_genericsatellite_crg_clk125_buf]'. [top.xdc:341]
Resolution: Check if the specified object(s) exists in the current design. If it does, ensure that the correct design hierarchy was specified for the object. If you are working with clocks, make sure create_clock was used to create the clock object before it is referenced.
```

The constraint in question sets false path with `clk125_buf`, but it only drives the QPLL, which should be unrelated to `cd_bootstrap`.

### Related
https://github.com/m-labs/artiq/issues/2093