### PR TITLE
CXP: add Host Rx core

### DIFF
--- a/misoc/cores/coaxpress/common.py
+++ b/misoc/cores/coaxpress/common.py
@@ -28,3 +28,9 @@ KCode = {
     "idle_comma": C(_K(28, 5), char_width),
     "idle_alignment": C(_K(28, 1), char_width),
 }
+
+
+def switch_endianness(s):
+    assert len(s) % 8 == 0
+    char = [s[i * 8 : (i + 1) * 8] for i in range(len(s) // 8)]
+    return Cat(char[::-1])

--- a/misoc/cores/coaxpress/common.py
+++ b/misoc/cores/coaxpress/common.py
@@ -6,6 +6,13 @@ char_layout = [("data", char_width), ("k", char_width // 8)]
 word_width = 32
 word_layout = [("data", word_width), ("k", word_width // 8)]
 
+word_layout_dchar = [
+    ("data", word_width),
+    ("k", word_width // 8),
+    ("dchar", char_width),
+    ("dchar_k", char_width // 8),
+]
+
 
 def _K(x, y):
     return (y << 5) | x

--- a/misoc/cores/coaxpress/core/__init__.py
+++ b/misoc/cores/coaxpress/core/__init__.py
@@ -1,11 +1,30 @@
 from migen import *
+from migen.genlib.cdc import MultiReg, PulseSynchronizer
 
 from misoc.interconnect.csr import *
-from misoc.interconnect.stream import StrideConverter
-from misoc.cores.coaxpress.common import char_layout, char_width, word_layout 
+from misoc.interconnect.stream import Buffer, StrideConverter
+from misoc.cores.coaxpress.common import (
+    char_layout,
+    char_width,
+    word_layout,
+    word_layout_dchar,
+)
+from misoc.cores.coaxpress.core.dchar import Duplicated_Char_Decoder
 from misoc.cores.coaxpress.core.idle import Idle_Word_Inserter
-from misoc.cores.coaxpress.core.packet import Command_Test_Packet_Writer, Packet_Wrapper 
-from misoc.cores.coaxpress.core.trigger import Trigger_ACK_Inserter, Trigger_Inserter
+from misoc.cores.coaxpress.core.packet import (
+    Command_Packet_Reader,
+    Command_Test_Packet_Writer,
+    Heartbeat_Packet_Reader,
+    Packet_Arbiter,
+    Packet_Wrapper,
+    Test_Sequence_Checker,
+)
+from misoc.cores.coaxpress.core.trigger import (
+    Trigger_ACK_Inserter,
+    Trigger_ACK_Reader,
+    Trigger_Inserter,
+    Trigger_Reader,
+)
 
 
 class HostTXCore(Module, AutoCSR):
@@ -82,3 +101,176 @@ class HostTXCore(Module, AutoCSR):
         for s, d in zip(tx_pipeline, tx_pipeline[1:]):
             self.comb += s.source.connect(d.sink)
 
+
+class HostRXCore(Module, AutoCSR):
+    def __init__(self, phy, command_buffer_depth, nslot, with_trigger):
+        self.ready = CSRStatus()
+
+        self.trigger_ack = CSR()
+
+        self.pending_packet = CSR()
+        self.read_ptr = CSRStatus(log2_int(nslot))
+        self.reader_buffer_err = CSR()
+
+        self.reader_decode_err = CSR()
+        self.test_error_counter = CSRStatus(16)
+        self.test_packet_counter = CSRStatus(16)
+        self.test_counts_reset = CSR()
+
+        self.heartbeat = CSR()
+        self.host_id = CSRStatus(32)
+        self.device_time = CSRStatus(64)
+
+        if with_trigger:
+            self.trig = Signal()
+            self.trig_delay = Signal(char_width)
+            self.trig_linktrigger_n = Signal(char_width)
+        
+        # # #
+
+        gtx = phy.gtx
+        self.sync += self.ready.status.eq(gtx.rx_ready),
+
+        # Host rx pipeline 
+        #
+        #        32             32+8(dchar)
+        # PHY ───/───> dchar   ─────/─────> trigger  ─────> trigger ack  ─────> buffer ─────>  packet arbiter ─────> stream packet with K29.7
+        #              decoder              reader          reader                                    │  │  │ 
+        #                                 (optional)                                                  │  │  └──────> test sequence checker
+        #                                                                                             │  │
+        #                                                                                             │  └─────────> heartbeat packet reader
+        #                                                                                             │   
+        #                                                                                             └────────────> command packet reader
+        #  
+        cdr = ClockDomainsRenamer("cxp_gt_rx")
+
+        # decode all incoming data as duplicate char and inject the result into the bus for downstream modules
+        self.submodules.dchar_decoder = dchar_decoder = cdr(Duplicated_Char_Decoder())
+
+        # Priority level 0 packet - Trigger packet
+        if with_trigger:
+            self.submodules.trig_reader = trig_reader = cdr(Trigger_Reader())
+            self.sync.cxp_gt_rx += [
+                self.trig.eq(trig_reader.trig),
+                self.trig_delay.eq(trig_reader.delay),
+                self.trig_linktrigger_n.eq(trig_reader.linktrigger_n),
+            ]
+
+        # Priority level 1 packet - Trigger ack packet
+        self.submodules.trig_ack_reader= trig_ack_reader = cdr(Trigger_ACK_Reader())
+        
+        self.submodules.trig_ack_ps = trig_ack_ps = PulseSynchronizer("cxp_gt_rx", "sys")
+        self.sync.cxp_gt_rx += trig_ack_ps.i.eq(trig_ack_reader.ack)
+        self.sync += [
+            If(trig_ack_ps.o,
+                self.trigger_ack.w.eq(1),
+            ).Elif(self.trigger_ack.re,
+                self.trigger_ack.w.eq(0),
+            ),
+        ]
+
+        # Priority level 2 packet - stream, test, heartbeat and command packets
+        self.submodules.arbiter = arbiter = cdr(Packet_Arbiter())
+
+        self.submodules.decode_err_ps = decode_err_ps = PulseSynchronizer("cxp_gt_rx", "sys")
+        self.sync.cxp_gt_rx += decode_err_ps.i.eq(arbiter.decode_err)
+        self.sync += [
+            If(decode_err_ps.o,
+                self.reader_decode_err.w.eq(1),
+            ).Elif(self.reader_decode_err.re,
+                self.reader_decode_err.w.eq(0),
+            ),
+        ]
+
+        # Buffer to improve timing
+        self.submodules.buffer = buffer = cdr(Buffer(word_layout_dchar))
+
+        if with_trigger:
+            rx_pipeline = [phy, dchar_decoder, trig_reader, trig_ack_reader, buffer, arbiter]
+        else:
+            rx_pipeline = [phy, dchar_decoder, trig_ack_reader, buffer, arbiter]
+        for s, d in zip(rx_pipeline, rx_pipeline[1:]):
+            self.comb += s.source.connect(d.sink)
+
+        # Stream packet
+        # set pipeline source to output stream packet 
+        self.source = arbiter.source_stream
+
+        # Test packet 
+        self.submodules.test_seq_checker = test_seq_checker = cdr(Test_Sequence_Checker())
+        self.comb += arbiter.source_test.connect(test_seq_checker.sink)
+        
+        self.submodules.test_reset_ps = test_reset_ps = PulseSynchronizer("sys", "cxp_gt_rx")
+        self.comb += test_reset_ps.i.eq(self.test_counts_reset.re),
+
+        test_err_cnt_rx = Signal.like(self.test_error_counter.status)
+        test_pak_cnt_rx = Signal.like(self.test_packet_counter.status)
+        test_err_r, test_pak_r = Signal(), Signal()
+        self.sync.cxp_gt_rx += [ 
+            test_err_r.eq(test_seq_checker.error),
+            test_pak_r.eq(arbiter.recv_test_pak),
+
+            If(test_reset_ps.o,
+                test_err_cnt_rx.eq(test_err_cnt_rx.reset),
+            ).Elif(test_err_r,
+                test_err_cnt_rx.eq(test_err_cnt_rx + 1),
+            ),
+            If(test_reset_ps.o,
+                test_pak_cnt_rx.eq(test_pak_cnt_rx.reset),
+            ).Elif(test_pak_r,
+                test_pak_cnt_rx.eq(test_pak_cnt_rx + 1),
+            ),
+        ]
+        self.specials += [
+            MultiReg(test_err_cnt_rx, self.test_error_counter.status),
+            MultiReg(test_pak_cnt_rx, self.test_packet_counter.status),
+        ]
+
+        # Command packet
+        self.submodules.command_reader = command_reader = cdr(Command_Packet_Reader(command_buffer_depth, nslot))
+        self.comb += arbiter.source_command.connect(command_reader.sink)
+
+        # nslot buffers control interface
+        write_ptr_sys = Signal.like(command_reader.write_ptr)
+        
+        self.specials += [
+            MultiReg(self.read_ptr.status, command_reader.read_ptr, odomain="cxp_gt_rx"),
+            MultiReg(command_reader.write_ptr, write_ptr_sys)
+        ]
+        self.sync += [
+            self.pending_packet.w.eq(self.read_ptr.status != write_ptr_sys),
+            If(~gtx.rx_ready,
+                self.read_ptr.status.eq(0),
+            ).Elif(self.pending_packet.re & self.pending_packet.w, 
+                self.read_ptr.status.eq(self.read_ptr.status + 1),
+            )
+        ]
+
+        self.submodules.buffer_err_ps = buffer_err_ps = PulseSynchronizer("cxp_gt_rx", "sys")
+        self.sync.cxp_gt_rx += buffer_err_ps.i.eq(command_reader.buffer_err),
+        self.sync += [
+            If(buffer_err_ps.o,
+                self.reader_buffer_err.w.eq(1),
+            ).Elif(self.reader_buffer_err.re,
+                self.reader_buffer_err.w.eq(0),
+            ),
+        ]
+
+        # Heartbeat packet
+        self.submodules.heartbeat_reader = heartbeat_reader = cdr(Heartbeat_Packet_Reader())
+        self.comb += arbiter.source_heartbeat.connect(heartbeat_reader.sink)
+
+        self.specials += [
+            MultiReg(heartbeat_reader.host_id, self.host_id.status),
+            MultiReg(heartbeat_reader.heartbeat, self.device_time.status),
+        ]
+        
+        self.submodules.heartbeat_ps = heartbeat_ps = PulseSynchronizer("cxp_gt_rx", "sys")
+        self.sync.cxp_gt_rx += heartbeat_ps.i.eq(arbiter.recv_heartbeat)
+        self.sync += [
+            If(heartbeat_ps.o,
+                self.heartbeat.w.eq(1),
+            ).Elif(self.heartbeat.re,
+                self.heartbeat.w.eq(0),
+            ),
+        ]

--- a/misoc/cores/coaxpress/core/dchar.py
+++ b/misoc/cores/coaxpress/core/dchar.py
@@ -1,0 +1,64 @@
+from migen import *
+
+from misoc.cores.coaxpress.common import word_layout, word_layout_dchar
+from misoc.interconnect.stream import Endpoint
+
+from functools import reduce
+from itertools import combinations
+from operator import or_, and_
+
+
+class Duplicated_Char_Decoder(Module):
+    def __init__(self):
+        self.sink = Endpoint(word_layout)
+        self.source = Endpoint(word_layout_dchar)
+
+        # # #
+
+        # For duplicated characters, an error correction method (e.g. majority voting) is required to meet the CXP spec:
+        # RX decoder should immune to single bit errors when handling duplicated characters - Section 9.2.2.1 (CXP-001-2021)
+        #
+        #
+        #                               32
+        #             ┌───>  buffer  ───/───┐
+        #         32  │                     │   40
+        # sink ───/───┤                 8   ├───/───> source
+        #             │              (dchar)│
+        #             └───> majority ───/───┘
+        #                   voting
+        #
+        #
+        # Due to the tight setup/hold time requiremnt for 12.5Gbps CXP, the voting logic cannot be implemented as combinational logic
+        # Hence, a pipeline approach is needed to avoid any s/h violation, where the majority voting result are pre-calculate and injected into the bus immediate after the PHY.
+        # And any downstream modules can access the voting result anytime
+
+        # cycle 1 - buffer data & calculate intermediate result
+        buffer = Endpoint(word_layout)
+        self.sync += [
+            If(buffer.ack,
+                self.sink.connect(buffer, omit={"ack"}),
+            )
+        ]
+        self.comb += self.sink.ack.eq(buffer.ack)
+
+        # calculate ABC, ABD, ACD, BCD
+        chars = [{"data": self.sink.data[i * 8 : (i + 1) * 8], "k": self.sink.k[i]} for i in range(4)]
+        voters = [Record([("data", 8), ("k", 1)]) for _ in range(4)]
+
+        for i, comb in enumerate(combinations(chars, 3)):
+            self.sync += [
+                If(buffer.ack,
+                    voters[i].data.eq(reduce(and_, [char["data"] for char in comb])),
+                    voters[i].k.eq(reduce(and_, [char["k"] for char in comb])),
+                )
+            ]
+
+        # cycle 2 - inject the voting result
+        self.sync += [
+            If(self.source.ack,
+                buffer.connect(self.source, omit={"ack", "dchar", "dchar_k"}),
+                self.source.dchar.eq(Replicate(reduce(or_, [v.data for v in voters]), 4)),
+                self.source.dchar_k.eq(Replicate(reduce(or_, [v.k for v in voters]), 4)),
+            )
+        ]
+        self.comb += buffer.ack.eq(self.source.ack)

--- a/misoc/cores/coaxpress/phy/high_speed_gtx.py
+++ b/misoc/cores/coaxpress/phy/high_speed_gtx.py
@@ -1,0 +1,714 @@
+from migen import *
+from migen.genlib.cdc import MultiReg
+from migen.genlib.misc import WaitTimer
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from misoc.cores.coaxpress.common import word_layout
+from misoc.cores.code_8b10b import Encoder, Decoder
+from misoc.cores.gtx_7series_init import GTXInit, GTXInitPhaseAlignment
+from misoc.interconnect.csr import *
+from misoc.interconnect.stream import Endpoint
+
+
+from functools import reduce
+from operator import add
+
+
+class HostRXPHYs(Module, AutoCSR):
+    """
+    A highspeed multilane RX phys that support reconfigurable linerate with 8b10b encoding
+    Supported linerate: 1.25, 2.5, 3.125, 5, 6.25, 10, 12.5 Gbps 
+    """
+    def __init__(self, gt_refclk, pads, refclk_freq, master=0):
+        assert master <= len(pads)
+        
+        self.qpll_reset = CSR()
+        self.qpll_locked = CSRStatus()
+        self.gtx_refclk_stable = CSRStorage()
+        self.gtx_restart = CSR()
+
+        # DRP port
+        self.gtx_daddr = CSRStorage(9)
+        self.gtx_dread = CSR()
+        self.gtx_din_stb = CSR()
+        self.gtx_din = CSRStorage(16)
+        self.gtx_dout = CSRStatus(16)
+        self.gtx_dready = CSR()
+
+        self.phys = []
+        # # #
+
+        # For speed higher than 6.6Gbps, QPLL need to be used instead of CPLL - DS191 (v1.18.1) Table 9.1
+        self.submodules.qpll = qpll = QPLL(gt_refclk)
+        self.sync += self.qpll_locked.status.eq(qpll.lock)
+
+        for i, pad in enumerate(pads):
+            if len(pads) == 1:
+                rx_mode = "single"
+            else:
+                rx_mode = "master" if i == master else "slave"
+            rx = Receiver(qpll, pad, refclk_freq, rx_mode)
+            self.phys.append(rx)
+            setattr(self.submodules, "rx"+str(i), rx)
+
+        for i, phy in enumerate(self.phys):
+            if i == master:
+                # Connect master GTX connections' output DRP
+                self.sync += [
+                    If(phy.gtx.dready,
+                        self.gtx_dready.w.eq(1),
+                        self.gtx_dout.status.eq(phy.gtx.dout),
+                    ).Elif(self.gtx_dready.re,
+                        self.gtx_dready.w.eq(0),
+                    ),
+                ]
+            self.sync += [
+                phy.gtx.qpll_reset.eq(self.qpll_reset.re),
+                phy.gtx.refclk_ready.eq(self.gtx_refclk_stable.storage),
+                phy.gtx.rx_restart.eq(self.gtx_restart.re),
+            ]
+
+            # Connect all GTX connections' input DRP
+            self.sync += [
+                phy.gtx.daddr.eq(self.gtx_daddr.storage),
+                phy.gtx.den.eq(self.gtx_dread.re | self.gtx_din_stb.re),
+                phy.gtx.dwen.eq(self.gtx_din_stb.re),
+                phy.gtx.din.eq(self.gtx_din.storage),
+            ]
+            self.comb += phy.gtx.dclk.eq(ClockSignal("sys"))
+
+        # master rx_init will lock up when slaves_phaligndone signal is not connected
+        self.submodules.rx_phase_alignment = GTXInitPhaseAlignment([rx_phy.gtx.rx_init for rx_phy in self.phys])
+
+
+class Receiver(Module):
+    def __init__(self, qpll, pad, refclk_freq, rx_mode):
+        self.submodules.gtx = gtx = GTX(qpll, pad, refclk_freq, None, rx_mode)
+       
+        self.source = Endpoint(word_layout)
+
+        data_valid = Signal()
+        self.sync.cxp_gt_rx += [
+            data_valid.eq(gtx.comma_aligner.rxfsm.ongoing("READY")),
+
+            self.source.stb.eq(0),
+            If(data_valid & ~((gtx.decoders[0].d == 0xBC) & (gtx.decoders[0].k == 1)),
+                self.source.stb.eq(1),
+                self.source.data.eq(Cat(gtx.decoders[i].d for i in range(4))),
+                self.source.k.eq(Cat(gtx.decoders[i].k for i in range(4))),
+            )
+        ]
+
+
+class QPLL(Module, AutoCSR):
+    """
+    A frequency reconfigurable QPLL
+    Designed for 125 MHz gt refclk
+
+    The following QPLL settings only need upper band VCO (9.8-12.5 GHz) for all CXP linerate
+
+     linerate    GT REFCLK  Feedback   R/TXOut   |   VCO
+      (Gbps)     Divider    Divider    Divider   |  (GHz)
+    ──────────  ────────── ────────── ────────── | ───────
+       1.25         1         80         8       |   10
+       2.5          1         80         4       |   10
+       3.125        1         100        4       |   12.5
+       5            1         80         2       |   10
+       6.25         1         100        2       |   12.5
+       10           1         80         1       |   10
+       12.5         1         100        1       |   12.5
+    
+    Initial setting: linerate @ 1.25 Gbps
+    """
+    def __init__(self, gt_refclk):
+        self.clk = Signal()
+        self.refclk = Signal()
+        self.lock = Signal()
+        self.reset = Signal()
+
+        self.daddr = CSRStorage(8)
+        self.dread = CSR()
+        self.din_stb = CSR()
+        self.din = CSRStorage(16)
+
+        self.dout = CSRStatus(16)
+        self.dready = CSR()
+
+        # # #
+
+        # feedback divider = 80, refclk divider = 1 and R/Txout divider = 8
+        # refclk @ 125 MHz => VCO = 125*80/1 MHz = 10GHz and linerate = 10/8 Gbps = 1.25Gbps
+        qpll_fbdiv = 0b0100100000
+        qpll_fbdiv_ratio = 1
+        self.fbdiv = 80
+        self.refclk_div = 1
+        self.Xxout_div = 8
+
+        dready = Signal()
+        self.specials += [
+            Instance("GTXE2_COMMON",
+                i_QPLLREFCLKSEL=0b001,
+                i_GTREFCLK0=gt_refclk,         
+
+                i_QPLLPD=0,
+                i_QPLLRESET=self.reset,
+                i_QPLLLOCKEN=1,
+                o_QPLLLOCK=self.lock,
+                o_QPLLOUTCLK=self.clk,
+                o_QPLLOUTREFCLK=self.refclk,
+
+                # See UG476 (v1.12.1) Table 2-16
+                p_QPLL_FBDIV=qpll_fbdiv,
+                p_QPLL_FBDIV_RATIO=qpll_fbdiv_ratio,
+                p_QPLL_REFCLK_DIV=self.refclk_div,
+
+                # From 7 Series FPGAs Transceivers Wizard
+                p_BIAS_CFG=0x0000040000001000,
+                p_COMMON_CFG=0x00000000,
+                p_QPLL_CFG=0x0680181,
+                p_QPLL_CLKOUT_CFG=0b0000,
+                p_QPLL_COARSE_FREQ_OVRD=0b010000,
+                p_QPLL_COARSE_FREQ_OVRD_EN=0b0,
+                p_QPLL_CP=0b0000011111,
+                p_QPLL_CP_MONITOR_EN=0b0,
+                p_QPLL_DMONITOR_SEL=0b0,
+                p_QPLL_FBDIV_MONITOR_EN= 0b0,
+                p_QPLL_INIT_CFG=0x000006,
+                p_QPLL_LOCK_CFG=0x21E8,
+                p_QPLL_LPF=0b1111,
+             
+                # Reserved, values cannot be modified
+                i_BGBYPASSB=0b1,
+                i_BGMONITORENB=0b1,
+                i_BGPDB=0b1,
+                i_BGRCALOVRD=0b11111,
+                i_RCALENB=0b1,
+                i_QPLLRSVD1=0b0,
+                i_QPLLRSVD2=0b11111,
+
+                # Dynamic Reconfiguration Ports
+                i_DRPADDR=self.daddr.storage,
+                i_DRPCLK=ClockSignal("sys"),
+                i_DRPEN=(self.dread.re | self.din_stb.re),
+                i_DRPWE=self.din_stb.re,
+                i_DRPDI=self.din.storage,
+                o_DRPDO=self.dout.status,
+                o_DRPRDY=dready,
+            )
+        ]
+
+        self.sync += [
+            If(dready,
+               self.dready.w.eq(1),
+            ),
+            If(self.dready.re,
+               self.dready.w.eq(0),
+            ),
+        ]
+
+
+class Comma_Aligner(Module):
+    """
+    Xilinx transceivers are LSB first, and comma needs to be flipped
+    compared to the usual 8b10b binary representation.
+    """
+    def __init__(self, comma):
+        self.data = Signal(10)
+        self.comma_aligned = Signal()
+        self.comma_realigned = Signal()
+        self.comma_det = Signal()
+
+        self.aligner_en = Signal()
+        self.ready_sys = Signal()
+
+        # # #
+
+        # From UG476 (v1.12.1) p.228
+        # The built-in RXBYTEISALIGNED can be falsely asserted at linerate higher than 5Gbps
+        # The validity of data and comma needed to be checked externally
+
+        comma_n = ~comma & 0b1111111111
+
+        comma_seen = Signal()
+        error_seen = Signal()
+        one_counts = Signal(max=11)
+
+        # From CXP-001-2021 section 9.2.5.1
+        # For high speed connection an IDLE word shall be transmitted at least once every 100 words
+        counter_period = 200
+
+        counter = Signal(reset=counter_period-1, max=counter_period)
+        check_reset = Signal()
+        check = Signal()
+
+        self.sync.cxp_gt_rx += [
+            If(check_reset,
+                counter.eq(counter.reset),   
+                check.eq(0),
+            ).Elif(counter == 0,
+                check.eq(1),
+            ).Else(
+                counter.eq(counter - 1),   
+            ),
+
+            If(check_reset,
+                comma_seen.eq(0),
+            ).Elif((self.data[:10] == comma) | (self.data[:10] == comma_n),
+                comma_seen.eq(1)
+            ),
+
+            one_counts.eq(reduce(add, [self.data[i] for i in range(10)])),
+            If(check_reset,
+                error_seen.eq(0),
+            ).Elif((one_counts != 4) & (one_counts != 5) & (one_counts != 6),
+                error_seen.eq(1),
+            ),
+
+        ]
+
+        self.submodules.rxfsm = rxfsm = ClockDomainsRenamer("cxp_gt_rx")(FSM(reset_state="WAIT_COMMA"))
+
+        rxfsm.act("WAIT_COMMA",
+            If(self.comma_det,
+                NextState("ALIGNING"),
+            )
+        )
+
+        rxfsm.act("ALIGNING",
+            If(self.comma_aligned & (~self.comma_realigned),
+                NextState("WAIT_ALIGNED_DATA"),               
+            ).Else(
+                self.aligner_en.eq(1),
+            )
+        )
+
+        # From UG476 (v1.12.1) p.232
+        # wait for the aligned data to arrive at the FPGA RX interface 
+        # as there is a delay before the data is available after RXBYTEISALIGNED is asserted
+        self.submodules.timer = timer = ClockDomainsRenamer("cxp_gt_rx")(WaitTimer(10_000))
+
+        rxfsm.act("WAIT_ALIGNED_DATA",
+            timer.wait.eq(1),
+            check_reset.eq(1),
+            If(timer.done,
+                NextState("CHECKING"),
+            )
+        )
+
+        rxfsm.act("CHECKING",
+            If(check,
+                check_reset.eq(1),
+                If(comma_seen & (~error_seen),
+                    NextState("READY"),
+                ).Else(
+                    NextState("WAIT_COMMA")
+                )
+            )
+        )
+
+        ready = Signal()
+        self.specials += MultiReg(ready, self.ready_sys)
+        rxfsm.act("READY",
+            ready.eq(1),
+            If(check,
+                check_reset.eq(1),
+                If(~(comma_seen & (~error_seen)),
+                    NextState("WAIT_COMMA"),
+                )
+            )
+        )
+
+
+class GTX(Module):
+    """
+    A linerate reconfigurable 40bit width GTX with QPLL
+    Designed for 1.25, 2.5, 3.125, 5, 6.25, 10, 12.5 Gpbs
+
+    To change the linerate:
+    1) Change the QPLL VCO frequency
+    2) Update the TXOUT_DIV and TXUSRCLK frequency if using tx
+    3) Update the RXOUT_DIV and RXCDR_CFG if using rx
+    4) Reset the entire rx/tx
+    """
+    def __init__(self, qpll, pads, refclk_freq, tx_mode="single", rx_mode="single"):
+        assert tx_mode in ["single", "master", "slave", None]
+        assert rx_mode in ["single", "master", "slave", None]
+
+
+        self.refclk_ready = Signal()
+        self.qpll_reset = Signal()
+        self.tx_restart = Signal()
+        self.rx_restart = Signal()
+        self.loopback_mode = Signal(3)
+
+        self.txenable = Signal()
+        self.rx_ready = Signal()
+
+        # Dynamic Reconfiguration Ports
+        self.daddr = Signal(9)
+        self.dclk = Signal()
+        self.den = Signal()
+        self.dwen = Signal()
+        self.din = Signal(16)
+        self.dout = Signal(16)
+        self.dready = Signal()
+
+
+
+        # transceiver direct clock outputs
+        # useful to specify clock constraints in a way palatable to Vivado
+        self.txoutclk = Signal()
+        self.rxoutclk = Signal()
+
+        # # #
+
+        txdata = Signal(40)
+        rxdata = Signal(40)
+
+        if tx_mode:
+            self.submodules.tx_init = tx_init = GTXInit(refclk_freq, False, mode=tx_mode)
+            self.sync += [
+                tx_init.cplllock.eq(qpll.lock),
+                tx_init.clk_path_ready.eq(self.refclk_ready),
+                # qpll reset are hold high before gtxinit, otherwise GTXINIT FSM may sometimes lock up as
+                # qpll lock doesn't always deassert the next cycle after qpll reset = 1
+                If(self.refclk_ready,
+                    qpll.reset.eq(tx_init.cpllreset | self.qpll_reset),
+                ).Else(
+                    qpll.reset.eq(1),
+                )
+            ]
+
+            self.submodules.encoder = ClockDomainsRenamer("cxp_gt_tx")(Encoder(4, True))
+            self.comb += txdata.eq(Cat(self.encoder.output[0], self.encoder.output[1], self.encoder.output[2], self.encoder.output[3])),
+
+        if rx_mode:
+            self.submodules.rx_init = rx_init = GTXInit(refclk_freq, True, mode=rx_mode)
+            self.sync += [
+                rx_init.cplllock.eq(qpll.lock),
+                rx_init.clk_path_ready.eq(self.refclk_ready),
+            ]
+            if not tx_mode:
+                # qpll reset are hold high before gtxinit, otherwise GTXINIT FSM may sometimes lock up as
+                # qpll lock doesn't always deassert the next cycle after qpll reset = 1
+                self.sync += \
+                    If(self.refclk_ready,
+                        qpll.reset.eq(rx_init.cpllreset | self.qpll_reset),
+                    ).Else(
+                        qpll.reset.eq(1),
+                    )
+
+            self.submodules.decoders = [ClockDomainsRenamer("cxp_gt_rx")(
+                (Decoder(True))) for _ in range(4)]
+            self.comb += [
+                self.decoders[0].input.eq(rxdata[:10]),
+                self.decoders[1].input.eq(rxdata[10:20]),
+                self.decoders[2].input.eq(rxdata[20:30]),
+                self.decoders[3].input.eq(rxdata[30:]),
+            ]
+
+        comma_aligned = Signal()
+        comma_realigned = Signal()
+        comma_det = Signal()
+        comma_aligner_en = Signal()
+        # Note: the following parameters were set after consulting AR45360
+        self.specials += \
+            Instance("GTXE2_CHANNEL",
+                # PMA Attributes
+                p_PMA_RSV=0x001E7080,
+                p_PMA_RSV2=0x2050,              # PMA_RSV2[5] = 0: Eye scan feature disabled
+                p_PMA_RSV3=0,
+                p_PMA_RSV4=1,                   # PMA_RSV[4],RX_CM_TRIM[2:0] = 0b1010: Common mode 800mV
+                p_RX_BIAS_CFG=0b000000000100,
+                p_RX_OS_CFG=0b0000010000000,
+                p_RX_CLK25_DIV=5,
+                p_TX_CLK25_DIV=5,
+
+                # Power-Down Attributes
+                p_PD_TRANS_TIME_FROM_P2=0x3c,
+                p_PD_TRANS_TIME_NONE_P2=0x3c,
+                p_PD_TRANS_TIME_TO_P2=0x64,
+                i_CPLLPD=1,
+
+                # Transceiver Reset Mode Operation
+                i_GTRESETSEL       = 0, # sequential mode
+                i_RESETOVRD        = 0,
+                
+                # QPLL
+                i_QPLLCLK=qpll.clk,
+                i_QPLLREFCLK=qpll.refclk,
+                p_RXOUT_DIV=qpll.Xxout_div,
+                p_TXOUT_DIV=qpll.Xxout_div,
+                i_RXSYSCLKSEL=0b11, # use QPLL & QPLL's REFCLK
+                i_TXSYSCLKSEL=0b11, # use QPLL & CPLL's REFCLK
+
+                # TX clock
+                p_TXBUF_EN="FALSE",
+                p_TX_XCLK_SEL="TXUSR",
+                o_TXOUTCLK=self.txoutclk,
+                # i_TXSYSCLKSEL=0b00,
+                i_TXOUTCLKSEL=0b11,
+
+                # TX Startup/Reset
+                i_TXPHDLYRESET=0,
+                i_TXDLYBYPASS=0,
+                i_TXPHALIGNEN=1 if tx_mode in ["master", "slave"] else 0,
+                i_GTTXRESET=tx_init.gtXxreset if tx_mode else 0,
+                o_TXRESETDONE=tx_init.Xxresetdone if tx_mode else 0,
+                i_TXDLYSRESET=tx_init.Xxdlysreset if tx_mode else 0,
+                o_TXDLYSRESETDONE=tx_init.Xxdlysresetdone if tx_mode else 0,
+                i_TXPHINIT=tx_init.txphinit if tx_mode in ["master", "slave"] else 0,
+                o_TXPHINITDONE=tx_init.txphinitdone if tx_mode in ["master", "slave"] else Signal(),
+                i_TXPHALIGN=tx_init.Xxphalign if tx_mode in ["master", "slave"] else 0,
+                i_TXDLYEN=tx_init.Xxdlyen if tx_mode in ["master", "slave"] else 0,
+                o_TXPHALIGNDONE=tx_init.Xxphaligndone if tx_mode else 0,
+                i_TXUSERRDY=tx_init.Xxuserrdy if tx_mode else 0,
+                p_TXPMARESET_TIME=1,
+                p_TXPCSRESET_TIME=1,
+                i_TXINHIBIT=~self.txenable,
+
+                # TX data
+                p_TX_DATA_WIDTH=40,
+                p_TX_INT_DATAWIDTH=1, # 1 if a line rate is greater than 6.6 Gbps
+                i_TXCHARDISPMODE=Cat(txdata[9], txdata[19], txdata[29], txdata[39]),
+                i_TXCHARDISPVAL=Cat(txdata[8], txdata[18], txdata[28], txdata[38]),
+                i_TXDATA=Cat(txdata[:8], txdata[10:18], txdata[20:28], txdata[30:38]),
+                i_TXUSRCLK=ClockSignal("cxp_gt_tx") if tx_mode else 0,
+                i_TXUSRCLK2=ClockSignal("cxp_gt_tx") if tx_mode else 0,
+
+                # TX electrical
+                i_TXBUFDIFFCTRL=0b100,
+                i_TXDIFFCTRL=0b1000,
+
+                # RX Startup/Reset
+                i_RXPHDLYRESET=0,
+                i_RXDLYBYPASS=0,
+                i_RXPHALIGNEN=1 if rx_mode in ["master", "slave"] else 0,
+                i_GTRXRESET=rx_init.gtXxreset if rx_mode else 0,
+                o_RXRESETDONE=rx_init.Xxresetdone if rx_mode else 0,
+                i_RXDLYSRESET=rx_init.Xxdlysreset if rx_mode else 0,
+                o_RXDLYSRESETDONE=rx_init.Xxdlysresetdone if rx_mode else 0,
+                i_RXPHALIGN=rx_init.Xxphalign if rx_mode in ["master", "slave"] else 0,
+                i_RXDLYEN=rx_init.Xxdlyen if rx_mode in ["master", "slave"] else 0,
+                o_RXPHALIGNDONE=rx_init.Xxphaligndone if rx_mode else 0,
+                i_RXUSERRDY=rx_init.Xxuserrdy if rx_mode else 0,
+                p_RXPMARESET_TIME=1,
+                p_RXPCSRESET_TIME=1,
+
+                # RX AFE
+                p_RX_DFE_XYD_CFG=0,
+                p_RX_CM_SEL=0b11,               # RX_CM_SEL = 0b11: Common mode is programmable
+                p_RX_CM_TRIM=0b010,             # PMA_RSV[4],RX_CM_TRIM[2:0] = 0b1010: Common mode 800mV
+                i_RXDFEXYDEN=1,
+                i_RXDFEXYDHOLD=0,
+                i_RXDFEXYDOVRDEN=0,
+                i_RXLPMEN=1,                    # RXLPMEN = 1: LPM mode is enable for non scramble 8b10b data
+                p_RXLPM_HF_CFG=0b00000011110000,
+                p_RXLPM_LF_CFG=0b00000011110000,
+
+                p_RX_DFE_GAIN_CFG=0x0207EA,
+                p_RX_DFE_VP_CFG=0b00011111100000011,
+                p_RX_DFE_UT_CFG=0b10001000000000000,
+                p_RX_DFE_KL_CFG=0b0000011111110,
+                p_RX_DFE_KL_CFG2=0x3788140A,
+                p_RX_DFE_H2_CFG=0b000110000000,
+                p_RX_DFE_H3_CFG=0b000110000000,
+                p_RX_DFE_H4_CFG=0b00011100000,
+                p_RX_DFE_H5_CFG=0b00011100000,
+                p_RX_DFE_LPM_CFG=0x0904,        # RX_DFE_LPM_CFG = 0x0904: linerate <= 6.6Gb/s
+                                                #                = 0x0104: linerate > 6.6Gb/s
+
+                # RX clock
+                i_RXDDIEN=1,
+                i_RXOUTCLKSEL=0b010,
+                o_RXOUTCLK=self.rxoutclk,
+                i_RXUSRCLK=ClockSignal("cxp_gt_rx") if rx_mode else 0,
+                i_RXUSRCLK2=ClockSignal("cxp_gt_rx") if rx_mode else 0,
+
+                # RX Clock Correction Attributes
+                p_CLK_CORRECT_USE="FALSE",
+                p_CLK_COR_SEQ_1_1=0b0100000000,
+                p_CLK_COR_SEQ_2_1=0b0100000000,
+                p_CLK_COR_SEQ_1_ENABLE=0b1111,
+                p_CLK_COR_SEQ_2_ENABLE=0b1111,
+
+                # RX data
+                p_RX_DATA_WIDTH=40,
+                p_RX_INT_DATAWIDTH=1,   # 1 if a line rate is greater than 6.6 Gbps
+                o_RXDISPERR=Cat(rxdata[9], rxdata[19], rxdata[29], rxdata[39]),
+                o_RXCHARISK=Cat(rxdata[8], rxdata[18], rxdata[28], rxdata[38]),
+                o_RXDATA=Cat(rxdata[:8], rxdata[10:18], rxdata[20:28], rxdata[30:38]),
+
+                # RX Byte and Word Alignment Attributes
+                p_ALIGN_COMMA_DOUBLE="FALSE",
+                p_ALIGN_COMMA_ENABLE=0b1111111111,
+                p_ALIGN_COMMA_WORD=4, # align comma to rxdata[:10] only
+                p_ALIGN_MCOMMA_DET="TRUE",
+                p_ALIGN_MCOMMA_VALUE=0b1010000011,
+                p_ALIGN_PCOMMA_DET="TRUE",
+                p_ALIGN_PCOMMA_VALUE=0b0101111100,
+                p_SHOW_REALIGN_COMMA="FALSE",
+                p_RXSLIDE_AUTO_WAIT=7,
+                p_RXSLIDE_MODE="OFF",
+                p_RX_SIG_VALID_DLY=10,
+                i_RXPCOMMAALIGNEN=comma_aligner_en,
+                i_RXMCOMMAALIGNEN=comma_aligner_en,
+                i_RXCOMMADETEN=1,
+                i_RXSLIDE=0,
+                o_RXBYTEISALIGNED=comma_aligned,
+                o_RXBYTEREALIGN=comma_realigned,
+                o_RXCOMMADET=comma_det,
+
+                # RX 8B/10B Decoder Attributes
+                p_RX_DISPERR_SEQ_MATCH="FALSE",
+                p_DEC_MCOMMA_DETECT="TRUE",
+                p_DEC_PCOMMA_DETECT="TRUE",
+                p_DEC_VALID_COMMA_ONLY="FALSE",
+
+                # RX Buffer Attributes
+                p_RXBUF_ADDR_MODE="FAST",
+                p_RXBUF_EIDLE_HI_CNT=0b1000,
+                p_RXBUF_EIDLE_LO_CNT=0b0000,
+                p_RXBUF_EN="FALSE",
+                p_RX_BUFFER_CFG=0b000000,
+                p_RXBUF_RESET_ON_CB_CHANGE="TRUE",
+                p_RXBUF_RESET_ON_COMMAALIGN="FALSE",
+                p_RXBUF_RESET_ON_EIDLE="FALSE",     # RXBUF_RESET_ON_EIDLE = FALSE: OOB is disabled
+                p_RXBUF_RESET_ON_RATE_CHANGE="TRUE",
+                p_RXBUFRESET_TIME=0b00001,
+                p_RXBUF_THRESH_OVFLW=61,
+                p_RXBUF_THRESH_OVRD="FALSE",
+                p_RXBUF_THRESH_UNDFLW=4,
+                p_RXDLY_CFG=0x001F,
+                p_RXDLY_LCFG=0x030,
+                p_RXDLY_TAP_CFG=0x0000,
+                p_RXPH_CFG=0xC00002,
+                p_RXPHDLY_CFG=0x084020,
+                p_RXPH_MONITOR_SEL=0b00000,
+                p_RX_XCLK_SEL="RXUSR",
+                p_RX_DDI_SEL=0b000000,
+                p_RX_DEFER_RESET_BUF_EN="TRUE",
+
+                # CDR Attributes
+                p_RXCDR_CFG=0x03_0000_23FF_1008_0020,   # LPM @ 0.5G-1.5625G , 8B/10B encoded data, CDR setting < +/- 200ppm
+                                                        # (See UG476 (v1.12.1), p.206)
+                p_RXCDR_FR_RESET_ON_EIDLE=0b0,
+                p_RXCDR_HOLD_DURING_EIDLE=0b0,
+                p_RXCDR_PH_RESET_ON_EIDLE=0b0,
+                p_RXCDR_LOCK_CFG=0b010101,
+
+                # Pads
+                i_GTXRXP=pads.rxp if rx_mode else 0,
+                i_GTXRXN=pads.rxn if rx_mode else 0,
+                o_GTXTXP=pads.txp if tx_mode else 0,
+                o_GTXTXN=pads.txn if tx_mode else 0,
+
+                # Dynamic Reconfiguration Ports
+                p_IS_DRPCLK_INVERTED=0b0,
+                i_DRPADDR=self.daddr,
+                i_DRPCLK=self.dclk,
+                i_DRPEN=self.den,
+                i_DRPWE=self.dwen,
+                i_DRPDI=self.din,
+                o_DRPDO=self.dout,
+                o_DRPRDY=self.dready,
+
+                # Nearend Loopback
+                i_LOOPBACK = self.loopback_mode,
+                p_TX_LOOPBACK_DRIVE_HIZ = "FALSE",
+                p_RXPRBS_ERR_LOOPBACK = 0b0,
+
+                # Other parameters
+                p_PCS_RSVD_ATTR=(
+                    (tx_mode != "single") << 1 |    # PCS_RSVD_ATTR[1] = 0: TX Single Lane Auto Mode
+                                                    #                  = 1: TX Manual Mode
+                    (rx_mode != "single") << 2 |    #              [2] = 0: RX Single Lane Auto Mode
+                                                    #                  = 1: RX Manual Mode
+                    0 << 8                          #              [8] = 0: OOB is disabled
+                ),
+                i_RXELECIDLEMODE=0b11,              # RXELECIDLEMODE = 0b11: OOB is disabled
+                p_RX_DFE_LPM_HOLD_DURING_EIDLE=0b0,
+                p_ES_EYE_SCAN_EN="TRUE",            # Must be TRUE for GTX
+            )
+
+
+        # TX clocking
+        # When bypassing the TX buffer and changing frequency of VCO of QPLL/CPLL,
+        # TXUSRCLK rate will always be the refclk rate.
+        # To match the required TXUSRCLK rate = linerate/datewidth (UG476 (v1.12.1) Equation 3-1), a DRP PLL is used.
+         
+        # Slave TX will use cxp_gt_tx from master
+        if tx_mode == "single" or tx_mode == "master":
+            self.clock_domains.cd_cxp_gt_tx = ClockDomain()
+            txpll_fb_clk = Signal()
+            txoutclk_buf = Signal()
+            txpll_clkout = Signal()
+
+            self.txpll_reset = Signal()
+            self.pll_daddr = Signal(7)
+            self.pll_dclk = Signal()
+            self.pll_den = Signal()
+            self.pll_din = Signal(16)
+            self.pll_dwen = Signal()
+
+            self.txpll_locked = Signal()
+            self.pll_dout = Signal(16)
+            self.pll_dready = Signal()
+
+            pll_fbout_mult = 8
+            tx_usrclk_freq = ((refclk_freq*qpll.fbdiv)/(qpll.Xxout_div*qpll.refclk_div))/40
+            txusr_pll_div = pll_fbout_mult*refclk_freq/tx_usrclk_freq
+            self.specials += [
+                Instance("PLLE2_ADV",
+                    p_BANDWIDTH="HIGH",
+                    o_LOCKED=self.txpll_locked,
+                    i_RST=self.txpll_reset,
+                
+                    p_CLKIN1_PERIOD=1e9/refclk_freq, # ns
+                    i_CLKIN1=txoutclk_buf,
+
+                    # VCO @ 1.25GHz 
+                    p_CLKFBOUT_MULT=pll_fbout_mult, p_DIVCLK_DIVIDE=1,
+                    i_CLKFBIN=txpll_fb_clk, o_CLKFBOUT=txpll_fb_clk, 
+
+                    # frequency = linerate/40
+                    p_CLKOUT0_DIVIDE=txusr_pll_div, p_CLKOUT0_PHASE=0.0, o_CLKOUT0=txpll_clkout,
+
+                    # Dynamic Reconfiguration Ports
+                    i_DADDR = self.pll_daddr,
+                    i_DCLK = self.pll_dclk,
+                    i_DEN = self.pll_den,
+                    i_DI = self.pll_din,
+                    i_DWE = self.pll_dwen,
+                    o_DO = self.pll_dout,
+                    o_DRDY = self.pll_dready,
+                ),
+                Instance("BUFG", i_I=self.txoutclk, o_O=txoutclk_buf),
+                Instance("BUFG", i_I=txpll_clkout, o_O=self.cd_cxp_gt_tx.clk),
+                AsyncResetSynchronizer(self.cd_cxp_gt_tx, ~self.txpll_locked & ~tx_init.done)
+            ]
+            self.comb += tx_init.restart.eq(self.tx_restart)
+
+        # RX clocking
+        # When frequency of VCO of QPLL/CPLL is changed, RXUSRCLK will match the required frequency
+        # RXUSRCLK rate = linerate/datewidth (UG476 (v1.12.1) Equation 4-2). And PLL is not needed.
+        
+        # Slave RX will use cxp_gt_rx from master
+        if rx_mode == "single" or rx_mode == "master":
+            self.clock_domains.cd_cxp_gt_rx = ClockDomain()
+            self.specials += Instance("BUFG", i_I=self.rxoutclk, o_O=self.cd_cxp_gt_rx.clk),
+            # rxuserrdy is driven high when RXUSRCLK and RXUSRCLK2 are stable - UG476 (v1.12.1) p.75
+            self.specials += AsyncResetSynchronizer(self.cd_cxp_gt_rx, ~rx_init.Xxuserrdy)
+
+        if rx_mode:
+            self.comb += rx_init.restart.eq(self.rx_restart)
+
+            self.submodules.comma_aligner = comma_aligner = Comma_Aligner(0b0101111100)
+            self.sync.cxp_gt_rx += [
+                comma_aligner.data.eq(rxdata),
+                comma_aligner.comma_aligned.eq(comma_aligned),
+                comma_aligner.comma_realigned.eq(comma_realigned),
+                comma_aligner.comma_det.eq(comma_det),
+                comma_aligner_en.eq(comma_aligner.aligner_en),
+                self.rx_ready.eq(comma_aligner.ready_sys),
+            ]

--- a/misoc/cores/gtx_7series_init.py
+++ b/misoc/cores/gtx_7series_init.py
@@ -1,0 +1,257 @@
+from math import ceil
+
+from migen import *
+from migen.genlib.cdc import MultiReg
+from migen.genlib.misc import WaitTimer
+from migen.genlib.fsm import FSM
+
+
+class GTXInit(Module):
+    # Based on LiteSATA by Enjoy-Digital
+    # Choose between Auto Mode and Manual Mode for TX/RX phase alignment with buffer bypassed:
+    # * Auto Mode: When only single lane is involved, as suggested by Xilinx (AR59612)
+    # * Manual Mode: When only multi-lane is involved, as suggested by Xilinx (AR59612)
+    def __init__(self, clk_freq, rx, mode="single"):
+        assert isinstance(rx, bool)
+        assert mode in ["single", "master", "slave"]
+        self.mode = mode
+
+        self.clk_path_ready = Signal()
+
+        self.done = Signal()
+        self.restart = Signal()
+
+        # GTX signals
+        self.cplllock = Signal()
+        self.cpllreset = Signal()
+        self.gtXxreset = Signal()
+        self.Xxresetdone = Signal()
+        self.Xxdlysreset = Signal()
+        self.Xxdlysresetdone = Signal()
+        self.Xxphaligndone = Signal()
+        self.Xxuserrdy = Signal()
+        # GTX signals exclusive to multi-lane 
+        if mode != "single":
+            self.Xxphalign = Signal()
+            self.Xxdlyen = Signal()
+            # TX only:
+            if not rx:
+                self.txphinit = Signal()
+                self.txphinitdone = Signal()
+
+        # Strobe from master channel to initialize TX/RX phase alignment on slaves
+        self.master_phaligndone = Signal()
+        # Strobe from slave channels to re-enable TX/RX delay alignment on master;
+        # To be combinatorially AND-ed from all slave's `done`
+        if mode == "master":
+            self.slaves_phaligndone = Signal()
+
+        # # #
+
+        # Double-latch transceiver asynch outputs
+        cplllock = Signal()
+        Xxresetdone = Signal()
+        Xxdlysresetdone = Signal()
+        Xxphaligndone = Signal()
+        self.specials += [
+            MultiReg(self.cplllock, cplllock),
+            MultiReg(self.Xxresetdone, Xxresetdone),
+            MultiReg(self.Xxdlysresetdone, Xxdlysresetdone),
+            MultiReg(self.Xxphaligndone, Xxphaligndone),
+        ]
+        if mode != "single" and not rx:
+            txphinitdone = Signal()
+            self.specials += MultiReg(self.txphinitdone, txphinitdone)
+
+        # Deglitch FSM outputs driving transceiver asynch inputs
+        gtXxreset = Signal()
+        Xxdlysreset = Signal()
+        Xxuserrdy = Signal()
+        self.sync += [
+            self.gtXxreset.eq(gtXxreset),
+            self.Xxdlysreset.eq(Xxdlysreset),
+            self.Xxuserrdy.eq(Xxuserrdy)
+        ]
+        if mode != "single":
+            Xxphalign = Signal()
+            Xxdlyen = Signal()
+            self.sync += [
+                self.Xxphalign.eq(Xxphalign),
+                self.Xxdlyen.eq(Xxdlyen)
+            ]
+            if not rx:
+                txphinit = Signal()
+                self.sync += self.txphinit.eq(txphinit)
+
+        # After configuration, transceiver resets have to stay low for
+        # at least 500ns (see AR43482)
+        startup_cycles = ceil(500*clk_freq/1000000000)
+        startup_timer = WaitTimer(startup_cycles)
+        self.submodules += startup_timer
+
+        # PLL reset should be 1 period of refclk
+        # (i.e. 1/(125MHz) for the case of RTIO @ 125MHz)
+        pll_reset_cycles = ceil(clk_freq/125e6)
+        pll_reset_timer = WaitTimer(pll_reset_cycles)
+        self.submodules += pll_reset_timer
+
+        startup_fsm = FSM(reset_state="INITIAL")
+        self.submodules += startup_fsm
+
+        if rx:
+            cdr_stable_timer = WaitTimer(1024)
+            self.submodules += cdr_stable_timer
+
+        # Rising edge detection for phase alignment "done"
+        Xxphaligndone_r = Signal(reset=1)
+        Xxphaligndone_rising = Signal()
+        self.sync += Xxphaligndone_r.eq(Xxphaligndone)
+        self.comb += Xxphaligndone_rising.eq(Xxphaligndone & ~Xxphaligndone_r)
+
+        startup_fsm.act("INITIAL",
+            startup_timer.wait.eq(1),
+            If(startup_timer.done & self.clk_path_ready, NextState("RESET_PLL"))
+        )
+        startup_fsm.act("RESET_PLL",
+            gtXxreset.eq(1),
+            self.cpllreset.eq(1),
+            pll_reset_timer.wait.eq(1),
+            If(pll_reset_timer.done, NextState("RELEASE_PLL_RESET"))
+        )
+        startup_fsm.act("RELEASE_PLL_RESET",
+            gtXxreset.eq(1),
+            If(cplllock, NextState("RESET_GTX"))
+        )
+        startup_fsm.act("RESET_GTX",
+            gtXxreset.eq(1),
+            pll_reset_timer.wait.eq(1),
+            If(pll_reset_timer.done, NextState("RELEASE_GTX_RESET"))
+        )
+        # Release GTX reset and wait for GTX resetdone
+        # (from UG476, GTX is reset on falling edge
+        # of gttxreset)
+        if rx:
+            startup_fsm.act("RELEASE_GTX_RESET",
+                Xxuserrdy.eq(1),
+                cdr_stable_timer.wait.eq(1),
+                If(Xxresetdone & cdr_stable_timer.done, NextState("DELAY_ALIGN"))
+            )
+        else:
+            startup_fsm.act("RELEASE_GTX_RESET",
+                Xxuserrdy.eq(1),
+                If(Xxresetdone, NextState("DELAY_ALIGN"))
+            )
+
+        # States exclusive to Auto Mode:
+        if mode == "single":
+            # Start delay alignment (pulse)
+            startup_fsm.act("DELAY_ALIGN",
+                Xxuserrdy.eq(1),
+                Xxdlysreset.eq(1),
+                NextState("WAIT_DELAY_ALIGN")
+            )
+            # Wait for delay alignment
+            startup_fsm.act("WAIT_DELAY_ALIGN",
+                Xxuserrdy.eq(1),
+                If(Xxdlysresetdone, NextState("WAIT_FIRST_PHASE_ALIGN_DONE"))
+            )
+            # Wait 2 rising edges of rxphaligndone
+            # (from UG476 in buffer bypass config)
+            startup_fsm.act("WAIT_FIRST_PHASE_ALIGN_DONE",
+                Xxuserrdy.eq(1),
+                If(Xxphaligndone_rising, NextState("WAIT_SECOND_PHASE_ALIGN_DONE"))
+            )
+            startup_fsm.act("WAIT_SECOND_PHASE_ALIGN_DONE",
+                Xxuserrdy.eq(1),
+                If(Xxphaligndone_rising, NextState("READY"))
+            )
+
+        # States exclusive to Manual Mode:
+        else:
+            # Start delay alignment (hold)
+            startup_fsm.act("DELAY_ALIGN",
+                Xxuserrdy.eq(1),
+                Xxdlysreset.eq(1),
+                If(Xxdlysresetdone,
+                    # TX master: proceed to initialize phase alignment manually
+                    (NextState("PHASE_ALIGN_INIT") if not rx else
+                    # RX master: proceed to start phase alignment manually
+                    NextState("PHASE_ALIGN")) if mode == "master" else
+                    # TX/RX slave: wait for phase alignment "done" on master
+                    NextState("WAIT_MASTER")
+                )
+            )
+            if mode == "slave":
+                # TX slave: Wait for phase alignment "done" on master
+                startup_fsm.act("WAIT_MASTER",
+                    Xxuserrdy.eq(1),
+                    If(self.master_phaligndone,
+                        # TX slave: proceed to initialize phase alignment manually
+                        NextState("PHASE_ALIGN_INIT") if not rx else
+                        # RX slave: proceed to start phase alignment manually
+                        NextState("PHASE_ALIGN")
+                    )
+                )
+            if not rx:
+                # TX master/slave: Initialize phase alignment, wait rising edge on "done"
+                startup_fsm.act("PHASE_ALIGN_INIT",
+                    Xxuserrdy.eq(1),
+                    txphinit.eq(1),
+                    If(txphinitdone, NextState("PHASE_ALIGN"))
+                )
+            # Do phase ealignment, wait rising edge on "done"
+            startup_fsm.act("PHASE_ALIGN",
+                Xxuserrdy.eq(1),
+                Xxphalign.eq(1),
+                If(Xxphaligndone_rising,
+                    # TX/RX master: proceed to set T/RXDLYEN
+                    NextState("FIRST_DLYEN") if mode == "master" else
+                    # TX/RX slave: proceed to signal master
+                    NextState("READY")
+                )
+            )
+            if mode == "master":
+                # Enable delay alignment in manual mode, wait rising edge on phase alignment "done"
+                startup_fsm.act("FIRST_DLYEN",
+                    Xxuserrdy.eq(1),
+                    Xxdlyen.eq(1),
+                    If(Xxphaligndone_rising, NextState("WAIT_SLAVES"))
+                )
+                # Wait for phase alignment "done" on all slaves
+                startup_fsm.act("WAIT_SLAVES",
+                    Xxuserrdy.eq(1),
+                    self.master_phaligndone.eq(1),
+                    If(self.slaves_phaligndone, NextState("SECOND_DLYEN"))
+                )
+                # Re-enable delay alignment in manual mode, wait rising edge on phase alignment "done"
+                startup_fsm.act("SECOND_DLYEN",
+                    Xxuserrdy.eq(1),
+                    Xxdlyen.eq(1),
+                    If(Xxphaligndone_rising, NextState("READY"))
+                )
+
+        # Transceiver is ready, alignment can be restarted
+        startup_fsm.act("READY",
+            Xxuserrdy.eq(1),
+            self.done.eq(1),
+            If(self.restart, NextState("RESET_GTX"))
+        )
+
+
+class GTXInitPhaseAlignment(Module):
+    # Interconnect of phase alignment "done" signals for Manual Mode multi-lane
+    def __init__(self, gtx_inits):
+        master_phaligndone = Signal()   # Fan-out to `slave.master_phaligndone`s
+        slaves_phaligndone = Signal(reset=1)   # ANDed from `slave.done`s
+        # Slave channels
+        for gtx_init in gtx_inits:
+            if gtx_init.mode == "slave":
+                self.comb += gtx_init.master_phaligndone.eq(master_phaligndone)
+                slaves_phaligndone = slaves_phaligndone & gtx_init.done
+        # Master channels
+        for gtx_init in gtx_inits:
+            if gtx_init.mode == "master":
+                self.comb += [
+                    master_phaligndone.eq(gtx_init.master_phaligndone),
+                    gtx_init.slaves_phaligndone.eq(slaves_phaligndone)
+                ]

--- a/misoc/interconnect/stream.py
+++ b/misoc/interconnect/stream.py
@@ -316,3 +316,18 @@ class StrideConverter(Module):
                     j += width
         else:
             self.comb += source.payload.raw_bits().eq(converter.source.data)
+
+
+class Buffer(Module):
+    def __init__(self, layout):
+        self.sink = Endpoint(layout)
+        self.source = Endpoint(layout)
+
+        # # #
+
+        self.sync += \
+            If(self.source.ack,
+                self.sink.connect(self.source, omit={"ack"}),
+            ),
+
+        self.comb += self.sink.ack.eq(self.source.ack),


### PR DESCRIPTION
## Summary
- add buffer in `stream.py` 
- copy `gtx_7series_init.py` from artiq
- add helper function and layout in `common.py`
- add cxp rx phy with multilane support
   - add gtx and qpll with DRP support
   - support all CXP 2.1 linerate (1.25, 2.5, 3.125, 3.125, 5, 6.25, 10, 12.5 Gbps)
   - `GTX` module also include tx capability for future high speed uplink support (tho I cannot find any CXP camera that accept high speed uplink) 
- add duplicate char decoder
- add trigger, trigger ack reader (IO channel)
- add command, test sequence and heartbeat packet reader (Control channel) 
   - the `Memory` is used for Control/Event ack packet (software controlled) 
- add cxp rx host core
   - designed to run at phy data clock frequency (e.g. 312.5MHz @ 12.5Gbps)
   - use pipeline order to satisfy the CXP packet priority specification
   - use duplicate char decoder to 
      -  precalculate the majority voting result  to improve timing
      -  provides immunity to single bit errors
   - optional trigger reader (while the CXP diagram include the Trigger packet on the Host I am not sure why camera need to trigger the host that why I leave it optional)
   - add buffer to improve timing
   - connect packet arbiter to command, test sequence and heartbeat reader 
   - expose stream packet source for downstream consumption


```mermaid
flowchart TD
    phy(PHY)
    dchar(Duplicate char decoder) 
    trig("trigger reader (optional)") 
    trig_ack(trigger ack  reader)
    arbiter(packet arbiter)
    test(test sequence checker)
    heartbeat(heartbeat reader)
    command(command packet reader)
    stream("stream packet (for downstream consumption) ")

    phy -- 32 bit --> dchar -- 32+8 bit --> trig --> trig_ack --> arbiter
    arbiter --> test & heartbeat & command
    arbiter -.-> stream
  
```
## CXP Line procotol
![image](https://github.com/user-attachments/assets/e89b880c-f2cf-4e88-9893-0e9c7e71593a)

## Testing
- tested with TX core (#160) on zc706 with Basler boA2448-250c camera in 3.125, 5, 6.25, 10, 12.5 Gbps 
   - successfully read control command, test sequence, heartbeat and trigger ack packet
   - successfully receive trigger ack packet after send out a trigger packet
   - successfully receive frame packet after sending out a trigger
