### PR TITLE
cxp trigger: improve latency and add extra linktrigger support

### DIFF
--- a/misoc/cores/coaxpress/core/__init__.py
+++ b/misoc/cores/coaxpress/core/__init__.py
@@ -28,10 +28,10 @@ from misoc.cores.coaxpress.core.trigger import (
 
 
 class HostTXCore(Module, AutoCSR):
-    def __init__(self, phy, command_buffer_depth, with_trigger_ack):
+    def __init__(self, phy, command_buffer_depth, clk_freq, with_trigger_ack):
         self.trig_stb = Signal()
-        self.trig_delay = Signal(char_width)
-        self.trig_linktrigger_mode = Signal()
+        self.trig_linktrig_mode = Signal(2)
+        self.trig_extra_linktrig = Signal()
 
         if with_trigger_ack:
             self.trig_ack_stb = Signal()
@@ -59,11 +59,12 @@ class HostTXCore(Module, AutoCSR):
         
 
         # Priority level 0 packet - Trigger packet
-        self.submodules.trig = trig = Trigger_Inserter()
+        self.submodules.trig = trig = Trigger_Inserter(clk_freq)
         self.comb += [
             trig.stb.eq(self.trig_stb),
-            trig.delay.eq(self.trig_delay),
-            trig.linktrig_mode.eq(self.trig_linktrigger_mode)
+            trig.linktrig_mode.eq(self.trig_linktrig_mode),
+            trig.extra_linktrig.eq(self.trig_extra_linktrig),
+            trig.bitrate2x.eq(phy.bitrate2x_enable)
         ]
 
         # Priority level 1 packet - Trigger ack


### PR DESCRIPTION
After re-reading the cxp trigger spec again, the delay value should be handled by the cxp tx core instead of the exposing it to other module.
## Summary
- add delay calculation to reduce the jitter
- add extra linktrigger support (instead of only linktrigger0/linktrigger1, linktrigger2/linktrigger3 is also supported)
  -  since `delay` is not exposed anymore, the extra linktrigger support cannot be done externally  

![image](https://github.com/user-attachments/assets/fa3e2b79-d6be-4b9a-a315-1c3434509989)
Image from https://www.adimec.com/how-coaxpress-accurate-trigger-timing-correction-works/