### PR TITLE
CXP: fix inconsistent class name case

### DIFF
--- a/misoc/cores/coaxpress/core/crc.py
+++ b/misoc/cores/coaxpress/core/crc.py
@@ -33,7 +33,7 @@ class CXPCRC32(Module):
         ]
 
 
-class CXPCRC32_Checker(Module):
+class CXPCRC32Checker(Module):
     def __init__(self):
         self.error = Signal()
 

--- a/misoc/cores/coaxpress/core/dchar.py
+++ b/misoc/cores/coaxpress/core/dchar.py
@@ -8,7 +8,7 @@ from itertools import combinations
 from operator import or_, and_
 
 
-class Duplicated_Char_Decoder(Module):
+class DuplicatedCharDecoder(Module):
     def __init__(self):
         self.sink = Endpoint(word_layout)
         self.source = Endpoint(word_layout_dchar)

--- a/misoc/cores/coaxpress/core/idle.py
+++ b/misoc/cores/coaxpress/core/idle.py
@@ -3,7 +3,7 @@ from migen import *
 from misoc.cores.coaxpress.common import char_width, KCode, word_layout 
 from misoc.interconnect.stream import Endpoint
 
-class Idle_Word_Inserter(Module):
+class IdleWordInserter(Module):
     def __init__(self):
         # Section 9.2.5 (CXP-001-2021)
         # Send K28.5, K28.1, K28.1, D21.5  as idle word

--- a/misoc/cores/coaxpress/core/packet.py
+++ b/misoc/cores/coaxpress/core/packet.py
@@ -10,7 +10,7 @@ from misoc.cores.coaxpress.common import (
 )
 from misoc.interconnect.stream import Endpoint
 
-class Packet_Wrapper(Module):
+class PacketWrapper(Module):
     def __init__(self):
         self.sink = Endpoint(word_layout)
         self.source = Endpoint(word_layout)
@@ -54,7 +54,7 @@ class Packet_Wrapper(Module):
 
 
 @FullMemoryWE()
-class Command_Test_Packet_Writer(Module):
+class CommandTestPacketWriter(Module):
     def __init__(self, buffer_depth):
         self.word_len = Signal(log2_int(buffer_depth))
         self.stb = Signal()
@@ -137,7 +137,7 @@ class Command_Test_Packet_Writer(Module):
         )
 
 
-class Packet_Arbiter(Module):
+class PacketArbiter(Module):
     def __init__(self):
         self.decode_err = Signal()
         self.recv_test_pak = Signal()
@@ -245,7 +245,7 @@ class Packet_Arbiter(Module):
 
 
 @FullMemoryWE()
-class Command_Packet_Reader(Module):
+class CommandPacketReader(Module):
     def __init__(self, buffer_depth, nslot):
         self.write_ptr = Signal(log2_int(nslot))
         self.read_ptr = Signal.like(self.write_ptr)
@@ -312,7 +312,7 @@ class Command_Packet_Reader(Module):
         )
 
 
-class Heartbeat_Packet_Reader(Module):
+class HeartbeatPacketReader(Module):
     def __init__(self):
         self.host_id = Signal(4*char_width)
         self.heartbeat = Signal(8*char_width)
@@ -351,7 +351,7 @@ class Heartbeat_Packet_Reader(Module):
         ]
         
 
-class Test_Sequence_Checker(Module):
+class TestSequenceChecker(Module):
     def __init__(self):
         self.error = Signal()
 
@@ -389,7 +389,7 @@ class Test_Sequence_Checker(Module):
             ]
 
 
-class Stream_Packet_Arbiter(Module):
+class StreamPacketArbiter(Module):
     def __init__(self, stream_ids=[0]):
         n_id = len(stream_ids)
 

--- a/misoc/cores/coaxpress/core/trigger.py
+++ b/misoc/cores/coaxpress/core/trigger.py
@@ -3,7 +3,7 @@ from migen import *
 from misoc.cores.coaxpress.common import char_layout, char_width, KCode, word_layout, word_layout_dchar
 from misoc.interconnect.stream import Endpoint
 
-class Trigger_Inserter(Module):
+class TriggerInserter(Module):
     def __init__(self, clk_freq):
         self.stb = Signal()
         self.linktrig_mode = Signal(2)
@@ -92,7 +92,7 @@ class Trigger_Inserter(Module):
             )
         )
 
-class Trigger_ACK_Inserter(Module):
+class TriggerACKInserter(Module):
     def __init__(self):
         self.stb = Signal()
 
@@ -125,7 +125,7 @@ class Trigger_ACK_Inserter(Module):
             If(self.source.ack, NextState("COPY")),
         )
 
-class Trigger_Reader(Module):
+class TriggerReader(Module):
     def __init__(self):
         self.sink = Endpoint(word_layout_dchar)
         self.source = Endpoint(word_layout_dchar)
@@ -165,7 +165,7 @@ class Trigger_Reader(Module):
             )
         )
 
-class Trigger_ACK_Reader(Module):
+class TriggerACKReader(Module):
     def __init__(self):
         self.sink = Endpoint(word_layout_dchar)
         self.source = Endpoint(word_layout_dchar)

--- a/misoc/cores/coaxpress/phy/high_speed_gtx.py
+++ b/misoc/cores/coaxpress/phy/high_speed_gtx.py
@@ -207,7 +207,7 @@ class QPLL(Module, AutoCSR):
         ]
 
 
-class Comma_Aligner(Module):
+class CommaAligner(Module):
     """
     Xilinx transceivers are LSB first, and comma needs to be flipped
     compared to the usual 8b10b binary representation.
@@ -703,7 +703,7 @@ class GTX(Module):
         if rx_mode:
             self.comb += rx_init.restart.eq(self.rx_restart)
 
-            self.submodules.comma_aligner = comma_aligner = Comma_Aligner(0b0101111100)
+            self.submodules.comma_aligner = comma_aligner = CommaAligner(0b0101111100)
             self.sync.cxp_gt_rx += [
                 comma_aligner.data.eq(rxdata),
                 comma_aligner.comma_aligned.eq(comma_aligned),

--- a/misoc/cores/coaxpress/phy/low_speed_serdes.py
+++ b/misoc/cores/coaxpress/phy/low_speed_serdes.py
@@ -62,7 +62,7 @@ class Transmitter(Module, AutoCSR):
             )
         ]
 
-        self.submodules.serializer = serializer = Serializer_10bits(pad)
+        self.submodules.serializer = serializer = Serializer10bits(pad)
 
         self.comb += [
             cg.reset.eq(self.clk_reset),
@@ -117,7 +117,7 @@ class ClockGen(Module):
 
 @ResetInserter()
 @CEInserter()
-class Serializer_10bits(Module):
+class Serializer10bits(Module):
     def __init__(self, pad):
         self.oe = Signal()
         self.d = Signal(10)


### PR DESCRIPTION
unify all CXP class name to use camel case