### PR TITLE
spi2: Put register to I/O block for the 7-series interface

### DIFF
--- a/misoc/cores/spi2.py
+++ b/misoc/cores/spi2.py
@@ -50,7 +50,7 @@ class Register(Module):
         # Parallel data out (from serial)
         self.pdi = Signal(width)
         # Serial data out (from parallel)
-        self.sdo = Signal(reset_less=True)
+        self.sdo = Signal()
         # Serial data in
         # Must be sampled at a higher layer at self.sample
         self.sdi = Signal()
@@ -65,7 +65,7 @@ class Register(Module):
 
         ###
 
-        sr = Signal(width, reset_less=True)
+        sr = Signal(width)
 
         self.comb += [
             self.pdi.eq(Mux(self.lsb_first,


### PR DESCRIPTION
Ideally, this patch should only involve adding `"iob"` attributes.

However, IOB inference requires a direct connection from the register to the I/O pad (there are no logic in between).
- The internal `sdo` reaches the I/O pad directly.
Requiring users to supply an appropriate `sdo` keeps it as a direct connection.
- Tristate signals are either shared or derived via a LUT
Instead of having user to supply a variable length control signals that are identical, it now takes the tristate control signals 1 cycle in prior.

Require migen PR that adds IOB attribute.