### PR TITLE
kasli: use different region for PLL

### DIFF
--- a/misoc/targets/kasli.py
+++ b/misoc/targets/kasli.py
@@ -161,7 +161,7 @@ class _RtioSysCRG(Module, AutoCSR):
         # There are no CMT tiles in the IBUFDS_GT's clock region (X1Y3)
         # Place the PLL in the adjacent clock region
         platform.add_platform_command(
-            "set_property LOC PLLE2_ADV_X0Y3 [get_cells {pll}]", pll=self.pll)
+            "set_property LOC PLLE2_ADV_X1Y2 [get_cells {pll}]", pll=self.pll)
         self.specials += [
             Instance("BUFG", i_I=pll_clk_bootstrap, o_O=self.cd_bootstrap.clk),
             Instance("BUFG", i_I=pll_clk200, o_O=self.cd_clk200.clk),


### PR DESCRIPTION
Some specific ARTIQ Kasli configurations (especially ones using a Grabber) may fail to compile with an unroutable clock connection.

That is because of changes done in #156 - Grabber needs a PLL in a specific region depending on its connection, that may collide with the bootstrap clock PLL. Removing the constraint completely allows the placer to succeed; in that case the PLL is placed by default in X0Y0. That however according to UG472 comes at the price of phase offset (arguably not important for the bootstrap clock), but we can do a little better.

Thus the PLL is moved to another adjacent tile that does not collide with Grabber's PLL - tested with configurations with the Grabber at multiple EEM locations; and the timing is still met.